### PR TITLE
added option to select languages from treesitter config and smart indent

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -28,6 +28,8 @@ require "highlights"
 
 -- blankline
 
+vim.bo.smartindent = true --smartindent
+
 g.indentLine_enabled = 1
 g.indent_blankline_char = "▏"
 

--- a/init.lua
+++ b/init.lua
@@ -27,9 +27,6 @@ base16(base16.themes["onedark"], true)
 require "highlights"
 
 -- blankline
-
-vim.bo.smartindent = true --smartindent
-
 g.indentLine_enabled = 1
 g.indent_blankline_char = "▏"
 

--- a/init.lua
+++ b/init.lua
@@ -27,6 +27,8 @@ base16(base16.themes["onedark"], true)
 require "highlights"
 
 -- blankline
+vim.bo.smartindent = true --smartindent
+
 g.indentLine_enabled = 1
 g.indent_blankline_char = "▏"
 

--- a/lua/treesitter-nvim.lua
+++ b/lua/treesitter-nvim.lua
@@ -8,10 +8,56 @@ ts_config.setup {
         "bash",
         "lua",
         "json",
-        "python"
+        "python",
+        -- "c",
+        -- "c_sharp",
+        -- "clojure",
+        -- "comment",
+        -- "cpp",
+        -- "commonlisp",
+        -- "cuda",
+        -- "dart",
+        -- "devicetree",
+        -- "dockerfile",
+        -- "elixir",
+        -- "erlang",
+        -- "go",
+        -- "fish",
+        -- "haskell",
+        -- "java",
+        -- "jsdoc",
+        -- "graphql",
+        -- "julia",
+        -- "kotlin",
+        -- "ledger",
+        -- "latex",
+        -- "php",
+        -- "nix",
+        -- "ocamel",
+        -- "ql",
+        -- "regex",
+        -- "ruby",
+        -- "rust",
+        -- "rst",
+        -- "scss",
+        -- "sparql",
+        -- "teal",
+        -- "toml",
+        -- "typescript",
+        -- "vue",
+        -- "yaml",
+        -- "zig"
     },
+  -- ignore_install = { "php" }, -- List of parsers to ignore installing
     highlight = {
         enable = true,
         use_languagetree = true
     }
+}
+
+-- Treesitter Based indentation
+ts_config.setup {
+  indent = {
+    enable = true
+  }
 }


### PR DESCRIPTION
Hello I added the following things:

- To select languages from the treesitter config
- Treesitter based indentation
- Option for smart indentation was added in init.lua