### PR TITLE
cmd instead of vim.cmd

### DIFF
--- a/lua/highlights.lua
+++ b/lua/highlights.lua
@@ -137,4 +137,4 @@ fg("DashboardShortcut", grey_fg)
 fg("DashboardFooter", black)
 
 -- Default nvim bg
--- cmd("hi Normal guibg=#1e222a")
+-- cmd "hi Normal guibg=#1e222a"

--- a/lua/highlights.lua
+++ b/lua/highlights.lua
@@ -137,4 +137,4 @@ fg("DashboardShortcut", grey_fg)
 fg("DashboardFooter", black)
 
 -- Default nvim bg
--- vim.cmd("hi Normal guibg=#1e222a")
+-- cmd("hi Normal guibg=#1e222a")


### PR DESCRIPTION
In the highlights.lua 

vim.cmd is changed to cmd as it is imported like that