### PR TITLE
removed syntax highlight

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -18,7 +18,7 @@ g.mapleader = " "
 g.auto_save = 0
 
 -- colorscheme related stuff
-cmd "syntax on"
+-- cmd "syntax on"
 
 local base16 = require "base16"
 base16(base16.themes["onedark"], true)


### PR DESCRIPTION
I commented the `syntax on` option. Since it is uneccessary because (treesitter is enable). It slows down the startup time too. Check it and see the difference