### PR TITLE
Update TrueZen.nvim after repository changed address

### DIFF
--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -156,7 +156,7 @@ return packer.startup(
         }
 
         use {
-            "kdav5758/TrueZen.nvim",
+            "Pocco81/TrueZen.nvim",
             cmd = {"TZAtaraxis", "TZMinimalist"},
             config = function()
                 require("zenmode").config()


### PR DESCRIPTION
TrueZen.nvim repository address has been changed from https://github.com/kdav5758/TrueZen.nvim to https://github.com/Pocco81/TrueZen.nvim. Without changing plugin path in pluginList.lua file, plugin cannot be updated. 