### PR TITLE
Fix LspInstall lazyload

### DIFF
--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -44,6 +44,9 @@ M.config = function()
     -- lspInstall + lspconfig stuff
 
     local function setup_servers()
+
+        vim.cmd [[packadd nvim-lspinstall]] -- If LspInstall is lazy loaded.
+
         require "lspinstall".setup()
         local servers = require "lspinstall".installed_servers()
 


### PR DESCRIPTION
We have to add lspinstall using packadd or error occurs when lspconfig config file is loaded.