### PR TITLE
Add escape to normal mode functionality with plugin

### DIFF
--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -35,7 +35,6 @@ map("n", "<leader>zm", ":TZMinimalist<CR>", opt)
 map("n", "<leader>zf", ":TZFocus<CR>", opt)
 
 map("n", "<C-s>", ":w <CR>", opt)
--- vim.cmd("inoremap jh <Esc>")
 
 -- Commenter Keybinding
 map("n", "<leader>/", ":CommentToggle<CR>", opt)

--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -138,6 +138,15 @@ return packer.startup(
 
         -- misc plugins
         use {
+            'jdhao/better-escape.vim',
+            disable = true,  -- delete line to enable plugin
+            event = 'InsertEnter',
+            config = function()
+              require("plugins.others").betterEscape()
+            end
+        }
+
+        use {
             "windwp/nvim-autopairs",
             after = "nvim-compe",
             config = function()

--- a/lua/plugins/others.lua
+++ b/lua/plugins/others.lua
@@ -51,4 +51,11 @@ M.blankline = function()
     vim.g.indent_blankline_show_first_indent_level = false
 end
 
+M.betterEscape = function()
+    vim.g.better_escape_shortcut = {"jk", "kj"}
+    --vim.g.better_escape_shortcut = 'jh'
+
+    --vim.g.better_escape_interval = 200
+end
+
 return M


### PR DESCRIPTION
Hi all,

I've added the [better-escape.vim](https://github.com/jdhao/better-escape.vim) plugin with this pull request,
the aim of the plugin is to enable the common escape key-bind: `-- vim.cmd("inoremap jh <Esc>")` 
This key-bind is present (but disabled) [in NvChad already](https://github.com/siduck76/NvChad/blob/main/lua/mappings.lua#L38).

BUT with better UI performance as it doesn't wait to print the 'j' character to the buffer. 

**NOTE: very minimal impact to StartupTime**
(I measured with the plugin disabled and enabled, the difference was ~ 0.5sec)

**NOTE: [this is disabled by default](https://github.com/siduck76/NvChad/pull/160/commits/76b58daad054bd90b5ee230f03f81f551fa91fcb#diff-16c5fdf1ca1112f3bff35b8d14a6de8a174c71ee275a1f057dbd3f4fbbeeff83R142),** within: 'pluginList.lua' line 142: "disable = true,"
(disabled by default as the original key-bind was disabled by default)

**tl;dr** escape bind feels far less laggy, mokeh like, monkeh happy




