### PR TITLE
Fix terminal config issues

### DIFF
--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -18,7 +18,10 @@ map("v", "x", [=[ "_x ]=], opt)
  this line too ]]
 --
 
+-- escape with 'jk' mapping
 vim.api.nvim_set_keymap("i", "jk", "<esc>", {})
+vim.api.nvim_set_keymap("v", "jk", "<esc>", {})
+vim.api.nvim_set_keymap("t", "jk", "<esc>", {})
 
 -- Don't copy the replaced text after pasting in visual mode
 map("v", "p", '"_dP', opt)

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -4,9 +4,8 @@ local M = {}
 M.hideStuff = function()
     vim.api.nvim_exec(
         [[
-   au BufEnter term://* setlocal nonumber
+   au TermOpen term://* setlocal nonumber laststatus=0
    au BufEnter,BufWinEnter,WinEnter,CmdwinEnter * if bufname('%') == "NvimTree" | set laststatus=0 | else | set laststatus=2 | endif
-   au BufEnter term://* set laststatus=0 
 ]],
         false
     )


### PR DESCRIPTION
This is a pretty small commit/pull, hope that's okay

This fixes an escape mapping and terminal opening mapping

**Fixes:**
1. escape 'jk' mapping not working in terminal mode
2. escape 'jk' mapping not working in visual mode
3. opening a new terminal buffer (with `<CNTL> + t + t`) did not hide line numbers
         (only after viewing another buffer and returning)
         it did work for the `<CNTL> + l` & `<CNTL> + x` mappings, as they were just splits
         (it still works for these mappings)

Planning to investigate some more term config, but starting with this
         
tl;dr: can escape term & visual better, 
            monkeh still cannot escape the sad