### PR TITLE
Even faster startup time | Fix formatting | Misc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -153,11 +153,7 @@ main() {
   if _NVIM="$(command -v nvim)"; then
     if _check_nvim_version; then
       printf "\n%s\n" "=> Neovim will now open." && sleep 1
-      if [ "${_UPDATE}" = "false" ]; then
-        "${_NVIM}" +":lua require 'pluginList' vim.cmd('PackerSync')"
-      else
-        "${_NVIM}"
-      fi
+      "${_NVIM}" +":lua require 'pluginList' vim.cmd('PackerSync')"
     else
       printf "Error: Neovim is installed, but version is lower than 0.5.x, install Neovim >= 5.x and then run nvim & do :PackerSync\n."
     fi

--- a/lua/options.lua
+++ b/lua/options.lua
@@ -19,7 +19,7 @@ opt.clipboard = "unnamedplus"
 opt.shortmess:append("sI")
 
 -- disable tilde on end of buffer: https://github.com/  neovim/neovim/pull/8546#issuecomment-643643758
-vim.cmd [[let &fcs='eob: ']]
+vim.cmd("let &fcs='eob: '")
 
 -- Numbers
 opt.number = true

--- a/lua/options.lua
+++ b/lua/options.lua
@@ -1,6 +1,13 @@
 local opt = vim.opt
 local g = vim.g
 
+-- Turn these off at startup, will be enabled later just before loading the theme
+vim.cmd([[
+    syntax off
+    filetype off
+    filetype plugin indent off
+]])
+
 opt.ruler = false
 opt.hidden = true
 opt.ignorecase = true

--- a/lua/packerInit.lua
+++ b/lua/packerInit.lua
@@ -1,7 +1,9 @@
+vim.cmd("packadd packer.nvim")
+
 local present, packer = pcall(require, "packer")
 
 if not present then
-    local packer_path = vim.fn.stdpath("data") .. "/site/pack/packer/start/packer.nvim"
+    local packer_path = vim.fn.stdpath("data") .. "/site/pack/packer/opt/packer.nvim"
 
     print("Cloning packer..")
     -- remove the dir before cloning
@@ -17,6 +19,7 @@ if not present then
         }
     )
 
+    vim.cmd("packadd packer.nvim")
     present, packer = pcall(require, "packer")
 
     if present then

--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -1,5 +1,3 @@
-vim.cmd [[packadd packer.nvim]]
-
 local present, _ = pcall(require, "packerInit")
 
 if present then

--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -1,4 +1,5 @@
 local present, _ = pcall(require, "packerInit")
+local packer
 
 if present then
     packer = require "packer"
@@ -10,9 +11,15 @@ local use = packer.use
 
 return packer.startup(
     function()
-        use {"wbthomason/packer.nvim", event = "VimEnter"}
+        use {
+            "wbthomason/packer.nvim",
+            event = "VimEnter"
+        }
 
-        use {"akinsho/nvim-bufferline.lua", after = "nvim-base16.lua"}
+        use {
+            "akinsho/nvim-bufferline.lua",
+            after = "nvim-base16.lua"
+        }
 
         use {
             "glepnir/galaxyline.nvim",
@@ -76,7 +83,7 @@ return packer.startup(
             config = function()
                 require "plugins.compe"
             end,
-            wants = {"LuaSnip"},
+            wants = "LuaSnip",
             requires = {
                 {
                     "L3MON4D3/LuaSnip",
@@ -93,7 +100,10 @@ return packer.startup(
             }
         }
 
-        use {"sbdchd/neoformat", cmd = "Neoformat"}
+        use {
+            "sbdchd/neoformat",
+            cmd = "Neoformat"
+        }
 
         -- file managing , picker etc
         use {
@@ -112,8 +122,14 @@ return packer.startup(
             end
         }
 
-        use {"nvim-lua/plenary.nvim", event = "BufRead"}
-        use {"nvim-lua/popup.nvim", after = "plenary.nvim"}
+        use {
+            "nvim-lua/plenary.nvim",
+            event = "BufRead"
+        }
+        use {
+            "nvim-lua/popup.nvim",
+            after = "plenary.nvim"
+        }
 
         use {
             "nvim-telescope/telescope.nvim",
@@ -123,7 +139,11 @@ return packer.startup(
             end
         }
 
-        use {"nvim-telescope/telescope-fzf-native.nvim", run = "make", cmd = "Telescope"}
+        use {
+            "nvim-telescope/telescope-fzf-native.nvim",
+            run = "make",
+            cmd = "Telescope"
+        }
         use {
             "nvim-telescope/telescope-media-files.nvim",
             cmd = "Telescope"
@@ -147,7 +167,10 @@ return packer.startup(
             end
         }
 
-        use {"andymass/vim-matchup", event = "CursorMoved"}
+        use {
+            "andymass/vim-matchup",
+            event = "CursorMoved"
+        }
 
         use {
             "terrortylor/nvim-comment",
@@ -171,7 +194,10 @@ return packer.startup(
             end
         }
 
-        use {"tweekmonster/startuptime.vim", cmd = "StartupTime"}
+        use {
+            "tweekmonster/startuptime.vim",
+            cmd = "StartupTime"
+        }
 
         -- load autosave only if its globally enabled
         use {
@@ -195,7 +221,11 @@ return packer.startup(
 
         use {
             "Pocco81/TrueZen.nvim",
-            cmd = {"TZAtaraxis", "TZMinimalist", "TZFocus"},
+            cmd = {
+                "TZAtaraxis",
+                "TZMinimalist",
+                "TZFocus"
+            },
             config = function()
                 require "plugins.zenmode"
             end

--- a/lua/plugins/luasnip.lua
+++ b/lua/plugins/luasnip.lua
@@ -1,11 +1,5 @@
-local luasnip
-if
-    not pcall(
-        function()
-            luasnip = require "luasnip"
-        end
-    )
- then
+local present, luasnip = pcall(require, "luasnip")
+if not present then
     return
 end
 

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -76,5 +76,8 @@ if
     )
  then
     -- This should only trigger when in need of PackerSync, so better do it
-    vim.cmd("PackerSync")
+    print("After completion of PackerSync, restart neovim.")
+    require("packer").sync("telescope-fzf-native.nvim", "telescope-media-files.nvim")
+    -- why compile too ? well, packer is supposed to compile with sync only, but sometimes it doesn't work
+    vim.cmd("PackerCompile")
 end

--- a/lua/theme.lua
+++ b/lua/theme.lua
@@ -4,7 +4,7 @@ local present, base16 = pcall(require, "base16")
 
 if present then
     base16(base16.themes["onedark"], true)
-    pcall(require, "highlights")
+    require "highlights"
     return true
 else
     return false

--- a/lua/theme.lua
+++ b/lua/theme.lua
@@ -3,6 +3,13 @@ vim.g.nvchad_theme = "onedark"
 local present, base16 = pcall(require, "base16")
 
 if present then
+    -- enabled these options, was disabled in options.lua
+    vim.cmd([[
+        syntax on
+        filetype on
+        filetype plugin indent on
+    ]])
+
     base16(base16.themes["onedark"], true)
     require "highlights"
     return true


### PR DESCRIPTION
install.sh: Run PackerSync from script after install too

```
as the corresponding code for that was removed from init.lua
```

init: Asynchronously load filetype and syntax

```
lots of improvement for startup time
```

Fix formatting | Misc

```
* fix formatting in pluginList, luasnip
 * don't use pcall on highlights
 * sync and compile fzf and media files only when the error occurs, add a
  help text telling tbe user to restart neovim
```
                                                   
packerInit: Clone packer at opt path as we are lazy loading

```
move packadd to packerInit
```