### PR TITLE
Fix buffers/tab terminal issues, improve terminal install scripting

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,27 +71,28 @@ _setup_terminal_shell() {
   _mappings_file="${_CONFIG_PATH}/lua/mappings.lua"
   # only ask for shellname if running in terminal
   if [ -t 1 ]; then
-    printf "%s\n: " "Which shell do you want to use ? [ Enter nothing for current shell ( $_CURRENT_SHELL ) ]"
-    read -r shellname
+    printf "\n%s\n" "Which shell do you want to use? (Eg. 2)"
+    printf "\t%s\n" "[ Enter nothing for current shell ( $_CURRENT_SHELL ) ]"
+    grep '^/bin/' '/etc/shells' | nl
+    read -r shellNUM
   fi
-  shellname="${shellname:-${_CURRENT_SHELL}}"
-  printf "%s\n" "$shellname"
 
-  # don't try to do any changes if given shellname is same as bash
-  if ! [ bash = "$shellname" ]; then
+  # don't try to do any changes user wants their default shell in nvim
+  if [ ! -z "$shellNUM" ]; then
+    shellpath=$(grep '^/bin/' '/etc/shells' | sed -n "$shellNUM p")
     # Reference: https://stackoverflow.com/a/4247319
-    if "${_SED}" -i'.bak' -e "s/bash/$shellname/g" "${_mappings_file}"; then
-      printf "\n%s\n" "=> Shell changed to $shellname on nvim successfully!"
+    # \( & \) will use regex brackets (for later reference with \1)
+    # ( & ) will match text brackets
+    if "${_SED}" --posix -i'.bak' -e "s=^\(map(.* \+*terminal\) \(.*)\)=\1$shellpath \2=g" "${_mappings_file}"; then
+      printf "%s\n" "=> Neovim shell changed to $shellpath successfully!"
     else
-      printf "\n%s\n" "Cannot edit with sed, edit ${_mappings_file} manually to replace bash with $shellname."
+      printf "%s\n" "Cannot edit with sed, edit ${_mappings_file} manually to replace bash with $shellpath."
     fi
     rm -f "${_mappings_file}".bak # delete backup file created by sed
-  else
-    printf "\n%s\n" "=> Shell changed to $shellname on nvim successfully!"
   fi
+    printf "%s\n\n" "=> Neovim shell will be ${shellpath:-${_CURRENT_SHELL}}"
   return 0
 }
-
 _setup_arguments() {
   # default variables to be used
   _CONFIG_PATH="${HOME}/.config/nvim"

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -27,9 +27,9 @@ vim.api.nvim_set_keymap("t", "jk", "<esc>", {})
 map("v", "p", '"_dP', opt)
 
 -- OPEN TERMINALS --
-map("n", "<C-l>", [[<Cmd>vnew term://bash <CR>]], opt) -- term over right
-map("n", "<C-x>", [[<Cmd> split term://bash | resize 10 <CR>]], opt) --  term bottom
-map("n", "<C-t>t", [[<Cmd> tabnew | term <CR>]], opt) -- term newtab
+map("n", "<C-l>", [[<Cmd> vnew +terminal | setlocal nobuflisted <CR>]], opt) -- term over right
+map("n", "<C-x>", [[<Cmd> 10new +terminal | setlocal nobuflisted <CR>]], opt) --  term bottom
+map("n", "<C-t>t", [[<Cmd> terminal <CR>]], opt) -- term buffer
 
 -- copy whole file content
 map("n", "<C-a>", [[ <Cmd> %y+<CR>]], opt)

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -133,7 +133,7 @@ map("n", "<Leader>fh", [[<Cmd>Telescope help_tags<CR>]], opt)
 map("n", "<Leader>fo", [[<Cmd>Telescope oldfiles<CR>]], opt)
 
 -- bufferline tab stuff
-map("n", "<S-t>", ":tabnew<CR>", opt) -- new tab
+map("n", "<S-t>", ":enew<CR>", opt) -- new tab
 map("n", "<S-x>", ":bd!<CR>", opt) -- close tab
 
 -- move between tabs

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -5,6 +5,7 @@ M.hideStuff = function()
     vim.api.nvim_exec(
         [[
    au TermOpen term://* setlocal nonumber laststatus=0
+   au TermClose term://* bd!
    au BufEnter,BufWinEnter,WinEnter,CmdwinEnter * if bufname('%') == "NvimTree" | set laststatus=0 | else | set laststatus=2 | endif
 ]],
         false


### PR DESCRIPTION
Hi all,
improvements for terminal integration below! :)

- There seems to be some config confusion between buffers & tabs, see [buffers vs. tabs](https://github.com/mhinz/vim-galore#buffers-windows-tabs), this removes tab functionality that wasn't properly configured.
- Improve terminal functionality
- Improve terminal section of install script


**tl;dr:** monkey installs & uses terminals better now

------------------------------------------------------------------------------------------------------------------------------------------------------

### **Detailed Changes**
**Tabs, buffers & terminals** - [mappings.lua](https://github.com/siduck76/NvChad/compare/main...G-Rowell:dev-terminalAndScript?expand=1#diff-a0766e1a2e02b2ea4daca632884f3b3da5484029148d88b3012ba2b14efcbef6)
-  Use proper neovim functions see note below
- `<CNTL> + t` no longer opens a new tab, opens a new buffer
- `<CNTL> + t + t` no longer opens a terminal in a new tab, opens a terminal in a new buffer
- `<CNTL> + l` & `<CNTL> + x` opens a terminal in a better fashion
- Split terminals no longer are listed buffers, hence you won't be `<TAB>`'ing' to them problematically
- Most users will want their nvim terminal to be the same as their normal terminal, so assumes that (in tandem with install.sh)
- [Automatically close terminal buffer when exiting](https://github.com/siduck76/NvChad/pull/167/commits/f35aa3c604e2f35d4339f868b9365bf846deb644#diff-9ba393182dd67917921f013bebaa70af6dfbeb359cf9506b991ed90644cf7be4R8) from within the terminal buffer
IE.
open terminal buffer
.....some commands...
type `<CNTL> + d` for normal terminal exit --- automatically closes buffer here now

Note: still can use `<CNTL + w + {h,j,k,l}` to swap between splits

Note: 
Don't open a split terminal with `vnew term://bash` or `split term://bash | resize 10`, 
opening a terminal through a filename syntax, instead of the proper neovim command,
Split is used to split a file (to view multiple parts simultaneously), use the proper command `new`

**Install scripting for desired terminal** - [install.sh](https://github.com/siduck76/NvChad/compare/main...G-Rowell:dev-terminalAndScript?expand=1#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f)
All changes below relate only the [`_setup_terminal_shell()`](https://github.com/G-Rowell/NvChad/blob/15f20e8437b468f9d4fe616251822f7eaa40a6ac/install.sh#L70-L95) in install.sh
- Better terminal choice section
- Better logging/output to the user
- Most users will want their nvim terminal to be the same as their normal terminal, so assumes that (in tandem with mappings.lua)
