### PR TITLE
Dev test custom user config

### DIFF
--- a/lua/user_config.lua
+++ b/lua/user_config.lua
@@ -1,0 +1,18 @@
+-- WARN: this file is specially ignored by git
+-- Src: https://stackoverflow.com/a/26245961
+-- to 'ignore' this file: git update-index --assume-unchanged <file>
+-- to un-'ignore' this file: git update-index --no-assume-unchanged <file>
+
+local function map(mode, lhs, rhs, opts)
+    local options = {noremap = true, silent = true}
+    if opts then
+        options = vim.tbl_extend("force", options, opts)
+    end
+    vim.api.nvim_set_keymap(mode, lhs, rhs, options)
+end
+
+local options = vim.opt
+local g = vim.g
+
+--I want to disable the line numbering for my setup
+--options.number = true


### PR DESCRIPTION
Hi all,

[This is related to this issue.](https://github.com/siduck76/NvChad/issues/68)

We are making custom user configs for NvChad, which don't interfere/merge-conflict 

.gitignore won't work for this, as the file is comitted,
we use `git update-index --assume-unchanged lua/custom.lua`

This seems to be a working prototype, but I'm intending this to be a part of [the discussion here](https://github.com/siduck76/NvChad/issues/68)
So feel free to comment, not certain this is ready to merge (but it is working!)


**tl;dr:** monkey set their own config to be banana coloured 