### PR TITLE
Lang servers error suppression and better "publish diagnostics" glyph

### DIFF
--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -94,3 +94,29 @@ vim.fn.sign_define("LspDiagnosticsSignError", {text = "", numhl = "LspDiagnos
 vim.fn.sign_define("LspDiagnosticsSignWarning", {text = "", numhl = "LspDiagnosticsDefaultWarning"})
 vim.fn.sign_define("LspDiagnosticsSignInformation", {text = "", numhl = "LspDiagnosticsDefaultInformation"})
 vim.fn.sign_define("LspDiagnosticsSignHint", {text = "", numhl = "LspDiagnosticsDefaultHint"})
+
+vim.lsp.handlers["textDocument/publishDiagnostics"] =
+    vim.lsp.with(
+    vim.lsp.diagnostic.on_publish_diagnostics,
+    {
+        virtual_text = {
+            -- prefix = "",
+            prefix = "",
+            spacing = 0
+        },
+        signs = true,
+        underline = true
+    }
+)
+
+-- suppress error messages from lang servers
+vim.notify = function(msg, log_level, _opts)
+    if msg:match("exit code") then
+        return
+    end
+    if log_level == vim.log.levels.ERROR then
+        vim.api.nvim_err_writeln(msg)
+    else
+        vim.api.nvim_echo({{msg}}, true, {})
+    end
+end


### PR DESCRIPTION
Added:
1. A glyph that's just a little but smaller. Small enough to be able to distinguish from other in-line lsp diagnostics.

It looks like this:

![image](https://user-images.githubusercontent.com/58336662/126370778-1df23e78-49de-4905-9f24-8a6fccb985bb.png)

Some others that people might like could be:
```
ﱢ  ﱡ  
```
(if they are not displayed properly is because you need a patched nerd font)

2. Suppressed error messages from language servers. Especially useful for `diagnosticls`.