### PR TITLE
Securely call modules and disable all builtin plugin

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,15 +1,24 @@
 require "options"
 
+local chad_modules = {
+    "pluginList",
+    "plugins.bufferline",
+	"mappings",
+	"utils",
+}
+
 local async
 async =
     vim.loop.new_async(
     vim.schedule_wrap(
         function()
-            require "pluginList"
-            require "plugins.bufferline"
-            require "mappings"
-            require("utils").hideStuff()
-
+            for i = 1, #chad_modules, 1 do
+                local ok, res = xpcall(require, debug.traceback, chad_modules[i])
+                if not (ok) then
+                    print("NvChad [E0]: There was an error loading the module '" .. chad_modules[i] .. "' -->")
+                    print(res) -- print stack traceback of the error
+                end
+            end
             async:close()
         end
     )

--- a/init.lua
+++ b/init.lua
@@ -15,7 +15,7 @@ async =
             for i = 1, #chad_modules, 1 do
                 local ok, res = xpcall(require, debug.traceback, chad_modules[i])
                 if not (ok) then
-                    print("NvChad [E0]: There was an error loading the module '" .. chad_modules[i] .. "' -->")
+                    print("Error loading module : " .. chad_modules[i])
                     print(res) -- print stack traceback of the error
                 end
             end

--- a/init.lua
+++ b/init.lua
@@ -3,8 +3,8 @@ require "options"
 local chad_modules = {
     "pluginList",
     "plugins.bufferline",
-	"mappings",
-	"utils",
+    "mappings",
+    "utils"
 }
 
 local async

--- a/lua/options.lua
+++ b/lua/options.lua
@@ -46,16 +46,29 @@ g.mapleader = " "
 g.auto_save = false
 
 -- disable builtin vim plugins
-g.loaded_gzip = 0
-g.loaded_tar = 0
-g.loaded_tarPlugin = 0
-g.loaded_zipPlugin = 0
-g.loaded_2html_plugin = 0
-g.loaded_netrw = 0
-g.loaded_netrwPlugin = 0
-g.loaded_matchit = 0
-g.loaded_matchparen = 0
-g.loaded_spec = 0
+local disabled_built_ins = {
+    "netrw",
+    "netrwPlugin",
+    "netrwSettings",
+    "netrwFileHandlers",
+    "gzip",
+    "zip",
+    "zipPlugin",
+    "tar",
+    "tarPlugin",
+    "getscript",
+    "getscriptPlugin",
+    "vimball",
+    "vimballPlugin",
+    "2html_plugin",
+    "logipat",
+    "rrhelper",
+    "spellfile_plugin"
+}
+
+for _, plugin in pairs(disabled_built_ins) do
+    vim.g["loaded_" .. plugin] = 1
+end
 
 local M = {}
 

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -1,5 +1,8 @@
 -- hide line numbers , statusline in specific buffers!
-vim.api.nvim_exec([[
+vim.api.nvim_exec(
+    [[
    au TermOpen term://* setlocal nonumber laststatus=0
    au BufEnter,BufWinEnter,WinEnter,CmdwinEnter * if bufname('%') == "NvimTree" | set laststatus=0 | else | set laststatus=2 | endif
-]], false)
+]],
+    false
+)

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -1,14 +1,5 @@
-local M = {}
-
 -- hide line numbers , statusline in specific buffers!
-M.hideStuff = function()
-    vim.api.nvim_exec(
-        [[
+vim.api.nvim_exec([[
    au TermOpen term://* setlocal nonumber laststatus=0
    au BufEnter,BufWinEnter,WinEnter,CmdwinEnter * if bufname('%') == "NvimTree" | set laststatus=0 | else | set laststatus=2 | endif
-]],
-        false
-    )
-end
-
-return M
+]], false)


### PR DESCRIPTION
This PR disables all builtin plugins because it wasn't being done before and also securely calls all of nvchad's modules.

**Why do we need to securely call the modules?**

The secure call feature that this PR implements assures that users will get a clear trackback to where the issue originated. This is an example of what the error message looks like if `x` given module fails to load:

![image](https://user-images.githubusercontent.com/58336662/126376083-e5547fc7-088a-40ba-86d3-75d800e0f12b.png)

As you can see it's easy to identify what's causing the issue.

Furthermore, another _huge_ advantage secure calls have is that no matter if the module being required failed, the other will still be able to work with "what's left". This guarantees that no matter how high up the issue occurs the rest should still be loaded. For example:


![image](https://user-images.githubusercontent.com/58336662/126376603-d20c0c0c-f775-4755-a4e7-1e96ce8d9c68.png)

If there was an error loading the `plugins.bufferline` module, then neither the `mappings` module nor the `utils` module would be loaded. However, with the secure calls implementation they will still load regardless of `plugins.bufferline` succeeding or not. 


Edit: forgot to mention that you shouldn't try to load the `options` module inside of the `async func`. Of course you can also securely call that but it must be outside of the `asyc`