### PR TITLE
Fix term crash bug, no auto-close finished term anymore

### DIFF
--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -1,7 +1,7 @@
 -- hide line numbers , statusline in specific buffers!
 vim.api.nvim_exec(
     [[
-   au TermOpen term://* setlocal nonumber laststatus=0
+   au TermOpen term://* setlocal nonumber
    au BufEnter,BufWinEnter,WinEnter,CmdwinEnter * if bufname('%') == "NvimTree" | set laststatus=0 | else | set laststatus=2 | endif
 ]],
     false

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -1,7 +1,7 @@
 -- hide line numbers , statusline in specific buffers!
 vim.api.nvim_exec(
     [[
-   au TermOpen term://* setlocal nonumber
+   au TermOpen term://* setlocal nonumber  laststatus=0
    au BufEnter,BufWinEnter,WinEnter,CmdwinEnter * if bufname('%') == "NvimTree" | set laststatus=0 | else | set laststatus=2 | endif
 ]],
     false

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -2,7 +2,6 @@
 vim.api.nvim_exec(
     [[
    au TermOpen term://* setlocal nonumber laststatus=0
-   au TermClose term://* bd!
    au BufEnter,BufWinEnter,WinEnter,CmdwinEnter * if bufname('%') == "NvimTree" | set laststatus=0 | else | set laststatus=2 | endif
 ]],
     false


### PR DESCRIPTION
Hi all,
[fix for a bug I introduced](https://github.com/siduck76/NvChad/pull/167#issuecomment-883833117)

**Bug fix**
- Fix closing terminal with `<SHIFT> + x` that is the only buffer (and opened with `<CNTL> + t + t`
      Now closes properly
      Now terminals that are quit from within using `<CNTL> + d` no longer automatically close that term buffer, may fix later
- Also fixes the status line issue too

@siduck76 planning on having a wander through docs & posts regarding the terminal,
so feel free to pull this but I may work more





**tl;dr:** monkey made bug, monkey a8 bug