### PR TITLE
Added javacafe color scheme

### DIFF
--- a/lua/themes/javacafe.lua
+++ b/lua/themes/javacafe.lua
@@ -1,0 +1,33 @@
+local colors = {
+    white = "#F0F4FC",
+    darker_black = "#10171f",
+    black = "#131a21", --  nvim bg
+    black2 = "#29343d",
+    one_bg = "#2c333f",
+    one_bg2 = "#373e4c",
+    one_bg3 = "#434c5e",
+    grey = "#4c566a",
+    grey_fg = "#565c68",
+    grey_fg2 = "#606672",
+    light_grey = "#646a76",
+    red = "#f9929b",
+    baby_pink = "#fca2aa",
+    pink = "#fca2af",
+    line = "#3b4b58", -- for lines like vertsplit
+    green = "#7ed491",
+    vibrant_green = "#a5d4af",
+    blue = "#bac8ef",
+    nord_blue = "#a3b8ef",
+    yellow = "#fbdf90",
+    sun = "#fbdf9a",
+    purple = "#d7c1ed",
+    dark_purple = "#ccaced",
+    teal = "#9ce5c0",
+    orange = "#e39a83",
+    cyan = "#c7e5d6",
+    statusline_bg = "#29343d",
+    lightbg = "#373e4c",
+    lightbg2 = "#2c333f"
+}
+
+return colors


### PR DESCRIPTION
[Relevant PR](https://github.com/siduck76/nvim-base16.lua/pull/2) in the `nvim-base16.lua` repo.

![image](https://user-images.githubusercontent.com/33443763/126883479-10462c3a-3912-4819-b6cb-a315169cd02d.png)
