### PR TITLE
Use jdhao/better-escape.vim | Allow moving the cursor through wrapped lines normally

### DIFF
--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -18,11 +18,6 @@ map("v", "x", [=[ "_x ]=], opt)
  this line too ]]
 --
 
--- escape with 'jk' mapping
-vim.api.nvim_set_keymap("i", "jk", "<esc>", {})
-vim.api.nvim_set_keymap("v", "jk", "<esc>", {})
-vim.api.nvim_set_keymap("t", "jk", "<esc>", {})
-
 -- Don't copy the replaced text after pasting in visual mode
 map("v", "p", '"_dP', opt)
 

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -26,6 +26,14 @@ vim.api.nvim_set_keymap("t", "jk", "<esc>", {})
 -- Don't copy the replaced text after pasting in visual mode
 map("v", "p", '"_dP', opt)
 
+-- Allow moving the cursor through wrapped lines with j, k, <Up> and <Down>
+-- http://www.reddit.com/r/vim/comments/2k4cbr/problem_with_gj_and_gk/
+-- empty mode is same as using :map
+map("", "j", 'v:count ? "j" : "gj"', {expr = true})
+map("", "k", 'v:count ? "k" : "gk"', {expr = true})
+map("", "<Down>", 'v:count ? "j" : "gj"', {expr = true})
+map("", "<Up>", 'v:count ? "k" : "gk"', {expr = true})
+
 -- OPEN TERMINALS --
 map("n", "<C-l>", ":vnew +terminal | setlocal nobuflisted <CR>", opt) -- term over right
 map("n", "<C-x>", ":10new +terminal | setlocal nobuflisted <CR>", opt) --  term bottom

--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -17,6 +17,14 @@ return packer.startup(
         }
 
         use {
+            "jdhao/better-escape.vim",
+            event = "InsertEnter",
+            config = function()
+                require "plugins.others".escape()
+            end
+        }
+
+        use {
             "akinsho/nvim-bufferline.lua",
             after = "nvim-base16.lua",
             config = function()
@@ -247,7 +255,7 @@ return packer.startup(
         use {
             "tpope/vim-fugitive",
             cmd = {
-              "Git"
+                "Git"
             }
         }
     end

--- a/lua/plugins/others.lua
+++ b/lua/plugins/others.lua
@@ -15,6 +15,11 @@ M.comment = function()
     end
 end
 
+M.escape = function()
+    vim.g.better_escape_interval = 300
+    vim.g.better_escape_shortcut = {"jk"}
+end
+
 M.lspkind = function()
     local present, lspkind = pcall(require, "lspkind")
     if present then


### PR DESCRIPTION
Use jdhao/better-escape.vim to handle jk as escape mappings

    only for insert mode ( so also works on terminal too )

    remove visual mode key binding, till we find a proper solution, because it is super annoying right now

    Original pr here: https://github.com/siduck76/NvChad/pull/160

---

mappings: Allow moving the cursor through wrapped lines normally

    This doesn't affect any other stuff like 10j or 10k