### PR TITLE
add XDG_CONFIG_HOME

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,7 @@ _setup_terminal_shell() {
 }
 _setup_arguments() {
   # default variables to be used
-  _CONFIG_PATH="${HOME}/.config/nvim"
+  _CONFIG_PATH="${XDG_CONFIG_HOME}/nvim"
   _UPDATE=""
   _BACKUP_PATH="${_CONFIG_PATH}.bak"
   _NO_BACKUP="false"

--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,7 @@ _setup_terminal_shell() {
 }
 _setup_arguments() {
   # default variables to be used
-  _CONFIG_PATH="${XDG_CONFIG_HOME}/nvim"
+  _CONFIG_PATH="${XDG_CONFIG_HOME:-${HOME}/.config}/nvim"
   _UPDATE=""
   _BACKUP_PATH="${_CONFIG_PATH}.bak"
   _NO_BACKUP="false"


### PR DESCRIPTION
I tried installing it on my system and it failed mostly because the NvChad was by default installed to the `.config` directory. I use a custom dir for my `XDG_CONFIG_HOME` so I figured if anyone has the same issue this would be an easy way to have it not work for them, the fallback dir here is `.config` if the user has not set a custom one.