### PR TITLE
Replaced 'bin/bash' with 'usr/bin/env bash' for better system compatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -256,7 +256,7 @@ _parse_args() {
         fi
 
         case ${argv[j]} in
-        --*) # End of all options.
+        --*) # End of all opt
             case ${argv[j]} in
             --) # End of all options.
                 break


### PR DESCRIPTION
`/usr/bin/bash` and `/bin/bash` aren't guaranteed to exist on many systems, but `/usr/bin/env` is. This change makes the shebang line `/usr/bin/env bash`, so that it works on any modern *nix type system. Tested in macOS, Ubuntu and WSL.