### PR TITLE
Fix: set local variables for commonly used `vim.*` stuff

### DIFF
--- a/lua/highlights.lua
+++ b/lua/highlights.lua
@@ -76,7 +76,7 @@ fg("NvimTreeVertSplit", darker_black)
 bg("NvimTreeVertSplit", darker_black)
 fg("NvimTreeEndOfBuffer", darker_black)
 
-vim.cmd("hi NvimTreeRootFolder gui=underline guifg=" .. purple)
+cmd("hi NvimTreeRootFolder gui=underline guifg=" .. purple)
 bg("NvimTreeNormal", darker_black)
 fg_bg("NvimTreeStatuslineNc", darker_black, darker_black)
 fg_bg("NvimTreeWindowPicker", red, black2)

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -1,3 +1,5 @@
+local cmd = vim.cmd
+
 local function map(mode, lhs, rhs, opts)
     local options = {noremap = true, silent = true}
     if opts then
@@ -152,11 +154,11 @@ map("n", "<Esc>", ":noh<CR>", opt)
 map("t", "jk", "<C-\\><C-n>", opt)
 
 -- Packer commands till because we are not loading it at startup
-vim.cmd("silent! command PackerCompile lua require 'pluginList' require('packer').compile()")
-vim.cmd("silent! command PackerInstall lua require 'pluginList' require('packer').install()")
-vim.cmd("silent! command PackerStatus lua require 'pluginList' require('packer').status()")
-vim.cmd("silent! command PackerSync lua require 'pluginList' require('packer').sync()")
-vim.cmd("silent! command PackerUpdate lua require 'pluginList' require('packer').update()")
+cmd("silent! command PackerCompile lua require 'pluginList' require('packer').compile()")
+cmd("silent! command PackerInstall lua require 'pluginList' require('packer').install()")
+cmd("silent! command PackerStatus lua require 'pluginList' require('packer').status()")
+cmd("silent! command PackerSync lua require 'pluginList' require('packer').sync()")
+cmd("silent! command PackerUpdate lua require 'pluginList' require('packer').update()")
 
 -- Vim Fugitive
 map("n", "<Leader>gs", ":Git<CR>", opt)

--- a/lua/options.lua
+++ b/lua/options.lua
@@ -1,42 +1,44 @@
 local options = require("chadrc").options
+local opt = vim.opt
+local g = vim.g
 
-vim.opt.undofile = options.permanent_undo
-vim.opt.ruler = options.ruler
-vim.opt.hidden = options.hidden
-vim.opt.ignorecase = options.ignorecase
-vim.opt.splitbelow = true
-vim.opt.splitright = true
-vim.opt.termguicolors = true
-vim.opt.cul = true
-vim.opt.mouse = options.mouse
-vim.opt.signcolumn = "yes"
-vim.opt.cmdheight = options.cmdheight
-vim.opt.updatetime = options.updatetime -- update interval for gitsigns
-vim.opt.timeoutlen = options.timeoutlen
-vim.opt.clipboard = options.clipboard
+opt.undofile = options.permanent_undo
+opt.ruler = options.ruler
+opt.hidden = options.hidden
+opt.ignorecase = options.ignorecase
+opt.splitbelow = true
+opt.splitright = true
+opt.termguicolors = true
+opt.cul = true
+opt.mouse = options.mouse
+opt.signcolumn = "yes"
+opt.cmdheight = options.cmdheight
+opt.updatetime = options.updatetime -- update interval for gitsigns
+opt.timeoutlen = options.timeoutlen
+opt.clipboard = options.clipboard
 
 -- disable nvim intro
-vim.opt.shortmess:append("sI")
+opt.shortmess:append("sI")
 
 -- disable tilde on end of buffer: https://github.com/  neovim/neovim/pull/8546#issuecomment-643643758
-vim.opt.fillchars = {eob = " "}
+opt.fillchars = {eob = " "}
 
 -- Numbers
-vim.opt.number = options.number
-vim.opt.numberwidth = options.numberwidth
--- vim.opt.relativenumber = true
+opt.number = options.number
+opt.numberwidth = options.numberwidth
+-- opt.relativenumber = true
 
 -- Indenline
-vim.opt.expandtab = options.expandtab
-vim.opt.shiftwidth = options.shiftwidth
-vim.opt.smartindent = options.smartindent
+opt.expandtab = options.expandtab
+opt.shiftwidth = options.shiftwidth
+opt.smartindent = options.smartindent
 
 -- go to previous/next line with h,l,left arrow and right arrow
 -- when cursor reaches end/beginning of line
-vim.opt.whichwrap:append("<>hl")
+opt.whichwrap:append("<>hl")
 
-vim.g.mapleader = options.mapleader
-vim.g.auto_save = options.autosave
+g.mapleader = options.mapleader
+g.auto_save = options.autosave
 
 -- disable builtin vim plugins
 local disabled_built_ins = {
@@ -61,7 +63,7 @@ local disabled_built_ins = {
 }
 
 for _, plugin in pairs(disabled_built_ins) do
-    vim.g["loaded_" .. plugin] = 1
+    g["loaded_" .. plugin] = 1
 end
 
 -- Don't show status line on vim terminals

--- a/lua/packerInit.lua
+++ b/lua/packerInit.lua
@@ -1,4 +1,6 @@
-vim.cmd("packadd packer.nvim")
+local cmd = vim.cmd
+
+cmd("packadd packer.nvim")
 
 local present, packer = pcall(require, "packer")
 
@@ -19,7 +21,7 @@ if not present then
         }
     )
 
-    vim.cmd("packadd packer.nvim")
+    cmd("packadd packer.nvim")
     present, packer = pcall(require, "packer")
 
     if present then


### PR DESCRIPTION
Instead of a having a bunch of:

```lua
vim.opt.myopt = true
vim.opt.test = {"smth"}
vim.opt.run = false
```

Let's use:

```lua
local opt = vim.opt

opt.myopt = true
opt.test = {"smth"}
opt.run = false
```