### PR TITLE
WIP - Added toggleterm, based upon curtanips work

### DIFF
--- a/lua/chadrc.lua
+++ b/lua/chadrc.lua
@@ -1,6 +1,10 @@
 local M = {
     ui = {
-        theme = "onedark"
+        theme = "onedark",
+        hidden_statusline = { -- these are filetypes, not pattern matched
+            "NvimTree",
+            "toggleterm"
+        }
     },
     options = {
         permanent_undo = true,
@@ -89,7 +93,7 @@ local M = {
         toggleterm = {
             toggle_window = "<leader>w",
             toggle_right = "<leader>v",
-            toggle_bot = "<leader>x",
+            toggle_bot = "<leader>h",
         },
         misc = {
             esc_Termmode = "jk",

--- a/lua/chadrc.lua
+++ b/lua/chadrc.lua
@@ -86,13 +86,15 @@ local M = {
             diffget_3 = "<leader>gl",
             git_blame = "<leader>gb"
         },
+        toggleterm = {
+            toggle_window = "<leader>w",
+            toggle_right = "<leader>v",
+            toggle_bot = "<leader>x",
+        },
         misc = {
-            openTerm_right = "<C-l>",
-            openTerm_bottom = "<C-x>",
-            openTerm_currentBuf = "<C-t>t",
+            esc_Termmode = "jk",
             copywhole_file = "<C-a>",
-            toggle_linenr = "<leader>n",
-            esc_Termmode = "jk"
+            toggle_linenr = "<leader>n"
         }
     }
 }

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -35,16 +35,31 @@ map("", "k", 'v:count ? "k" : "gk"', {expr = true})
 map("", "<Down>", 'v:count ? "j" : "gj"', {expr = true})
 map("", "<Up>", 'v:count ? "k" : "gk"', {expr = true})
 
--- OPEN TERMINALS --
-map("n", miscMap.openTerm_right, ":vnew +terminal | setlocal nobuflisted <CR>", opt) -- term over right
-map("n", miscMap.openTerm_bottom, ":10new +terminal | setlocal nobuflisted <CR>", opt) --  term bottom
-map("n", miscMap.openTerm_currentBuf, ":terminal <CR>", opt) -- term buffer
 
 -- copy whole file content
 map("n", miscMap.copywhole_file, ":%y+<CR>", opt)
 
 -- toggle numbers
 map("n", miscMap.toggle_linenr, ":set nu!<CR>", opt)
+
+-- open a new buffer as a Terminal
+-- get out of terminal with jk
+map("t", miscMap.esc_Termmode, "<C-\\><C-n>", opt)
+
+
+M.toggleterm = function()
+    local m = user_map.toggleterm
+
+    -- Open terminals
+    map("n", m.toggle_window, ":execute v:count . 'ToggleTerm direction=window' <CR>", opt)
+    map("n", m.toggle_right, ":execute v:count . 'ToggleTerm direction=vertical' <CR>", opt)
+    map("n", m.toggle_bot, ":execute v:count . 'ToggleTerm direction=horizontal' <CR>", opt)
+
+    -- 'Un' toggle a term from within terminal edit mode
+    map("t", m.toggle_window, "<C-\\><C-n> :ToggleTerm <CR>", opt)
+    map("t", m.toggle_right, "<C-\\><C-n> :ToggleTerm <CR>", opt)
+    map("t", m.toggle_bot, "<C-\\><C-n> :ToggleTerm <CR>", opt)
+end
 
 M.truezen = function()
     local m = user_map.truezen
@@ -112,9 +127,6 @@ end
 
 -- use ESC to turn off search highlighting
 map("n", "<Esc>", ":noh<CR>", opt)
-
--- get out of terminal with jk
-map("t", miscMap.esc_Termmode, "<C-\\><C-n>", opt)
 
 -- Packer commands till because we are not loading it at startup
 cmd("silent! command PackerCompile lua require 'pluginList' require('packer').compile()")

--- a/lua/options.lua
+++ b/lua/options.lua
@@ -66,9 +66,9 @@ for _, plugin in pairs(disabled_built_ins) do
     g["loaded_" .. plugin] = 1
 end
 
--- Don't show status line on vim terminals
-vim.cmd [[ au TermOpen term://* setlocal nonumber laststatus=0 ]]
-vim.cmd [[ au TermClose term://* setlocal number laststatus=2 ]]
+-- Don't show status line on certain windows
+vim.cmd [[ au TermOpen term://* setlocal nonumber norelativenumber ]]
+vim.cmd [[let hidden_statusline = luaeval('require("chadrc").ui.hidden_statusline') | autocmd BufEnter,BufWinEnter,WinEnter,CmdwinEnter,TermEnter * nested if index(hidden_statusline, &ft) >= 0 | set laststatus=0 | else | set laststatus=2 | endif]]
 
 -- Open a file from its last left off position
 -- vim.cmd [[ au BufReadPost * if expand('%:p') !~# '\m/\.git/' && line("'\"") > 1 && line("'\"") <= line("$") | exe "normal! g'\"" | endif ]]

--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -200,6 +200,16 @@ return packer.startup(
 
         -- misc plugins
         use {
+            "akinsho/nvim-toggleterm.lua",
+            event = "BufWinEnter",
+            config = function()
+                require "plugins.toggleterm"
+            end,
+            setup = function()
+                require "mappings".toggleterm()
+            end
+        }
+        use {
             "windwp/nvim-autopairs",
             after = "nvim-compe",
             config = function()

--- a/lua/plugins/nvimtree.lua
+++ b/lua/plugins/nvimtree.lua
@@ -93,6 +93,3 @@ g.nvim_tree_bindings = {
     {key = "q", cb = tree_cb("close")},
     {key = "g?", cb = tree_cb("toggle_help")}
 }
-
--- hide statusline when nvim tree is opened
-vim.cmd [[au BufEnter,BufWinEnter,WinEnter,CmdwinEnter * if bufname('%') == "NvimTree" | set laststatus=0 | else | set laststatus=2 | endif]]

--- a/lua/plugins/toggleterm.lua
+++ b/lua/plugins/toggleterm.lua
@@ -1,0 +1,33 @@
+local present, toggleterm = pcall(require, "toggleterm")
+if not present then
+    return
+end
+
+toggleterm.setup {
+      -- size can be a number or function which is passed the current terminal
+    size = function(term)
+        if term.direction == "horizontal" then
+            return 15
+        elseif term.direction == "vertical" then
+            return vim.o.columns * 0.4
+        end
+    end,
+    -- open_mapping = [[<C-\>]], -- mapping set in mappings.lua
+    hide_numbers = true, -- hide the number column in toggleterm buffers
+    shade_terminals = false,
+    start_in_insert = true,
+    -- insert_mappings = true, -- see 'open_mapping', not set on purpose
+        -- whether or not the open mapping applies in insert mode
+    persist_size = true,
+    direction = 'vertical',
+    close_on_exit = true, -- close the terminal window when the process exits
+    -- This field is only relevant if direction is set to 'float'
+    float_opts = {
+        border = 'single',
+        winblend = 0,
+        highlights = {
+            border = "Normal",
+            background = "Normal",
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This is some cool work that was started off by @curtainp!
So credit to them!

## improvements,
- Installed the [nvim-toggleterm.lua plugin](https://github.com/akinsho/nvim-toggleterm.lua)
- Setup various keybinds / autocommands for it
-- `<LEADER> + h` for a horizontal terminal
-- `<LEADER> + v` for a vertical terminal
-- `<LEADER> + w` for a window terminal    (this one is my fav)
- Improved the statusline hiding by adding a `chadrc.lua` table, `chadrc.ui.hidden_statusline`
-- now we can easily hide the statusline of any filetype!

## Todo
- Make the horizontal, vertical & terminals separate maybe?
-- `nvim-toggleterm.lua` does provide this functionality already, do we want to wrap it?


*tl;dr*: monkey uses terms better