### PR TITLE
Now have 3 separate terms, window, vert & hori, renamed some variables

### DIFF
--- a/lua/chadrc.lua
+++ b/lua/chadrc.lua
@@ -101,8 +101,9 @@ local M = {
         },
         toggleterm = {
             toggle_window = "<leader>w",
-            toggle_right = "<leader>v",
-            toggle_bot = "<leader>h"
+            toggle_vert = "<leader>v",
+            toggle_hori = "<leader>h",
+            hide_term = "JK"
         },
         insert_nav = {
             forward = "<C-l>",

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -49,14 +49,14 @@ M.toggleterm = function()
     local m = user_map.toggleterm
 
     -- Open terminals
-    map("n", m.toggle_window, ":execute v:count . 'ToggleTerm direction=window' <CR>", opt)
-    map("n", m.toggle_right, ":execute v:count . 'ToggleTerm direction=vertical' <CR>", opt)
-    map("n", m.toggle_bot, ":execute v:count . 'ToggleTerm direction=horizontal' <CR>", opt)
+    map("n", m.toggle_window, ":lua termW:toggle() <CR>", opt)
+    map("n", m.toggle_vert, ":lua termV:toggle() <CR>", opt)
+    map("n", m.toggle_hori, ":lua termH:toggle() <CR>", opt)
 
-    -- 'Un' toggle a term from within terminal edit mode
-    map("t", m.toggle_window, "<C-\\><C-n> :ToggleTerm <CR>", opt)
-    map("t", m.toggle_right, "<C-\\><C-n> :ToggleTerm <CR>", opt)
-    map("t", m.toggle_bot, "<C-\\><C-n> :ToggleTerm <CR>", opt)
+    -- toggle(HIDE) a term from within terminal edit mode
+    map("t", m.hide_term, "<C-\\><C-n> :ToggleTerm <CR>", opt)
+    map("t", m.hide_term, "<C-\\><C-n> :ToggleTerm <CR>", opt)
+    map("t", m.hide_term, "<C-\\><C-n> :ToggleTerm <CR>", opt)
 end
 
 M.truezen = function()

--- a/lua/plugins/toggleterm.lua
+++ b/lua/plugins/toggleterm.lua
@@ -31,3 +31,17 @@ toggleterm.setup {
         }
     }
 }
+
+local Terminal = require("toggleterm.terminal").Terminal
+
+_G.termW = Terminal:new {
+        direction = "window",
+}
+
+_G.termV = Terminal:new {
+        direction = "vertical",
+}
+
+_G.termH = Terminal:new {
+        direction = "horizontal",
+}


### PR DESCRIPTION
Hi all,

Currently this creates 3 persistent terminals for you to use,
you can do this all easily with native [nvim-toggleterm.lua](https://github.com/akinsho/nvim-toggleterm.lua) functionality, but this is just a wrapper for your 3 `main` terms.

## keybinds are as follows:
- `<leader> + w` for a window term (IE. full screen)
- `<leader> + h` for a horizontal term
- `<leader> + v` for a vertical term
These are each three distinct & persistent terminals
- `JK` (not `jk`) to escape mode & hide the term
- `jk` still exits terminal mode (not changed, just noting this here)

## improvements:
- currently this saves each of the three terms as global vars, we'll likely still have to do this....but we could format it in a nicer way
-- maybe have a global nvChad table, which can contain the theme, these 3 terms...etc.

## bugs:
- I think it may be possible to `break` the system & open a term twice, will investigate this (hence this is not ready for merging)