### PR TITLE
Correct bufferline diagnostics alternate setting

### DIFF
--- a/lua/plugins/configs/bufferline.lua
+++ b/lua/plugins/configs/bufferline.lua
@@ -26,7 +26,7 @@ bufferline.setup {
       show_buffer_close_icons = true,
       separator_style = "thin",
       always_show_bufferline = true,
-      diagnostics = false, -- "or nvim-lsp"
+      diagnostics = false, -- "or nvim_lsp"
 
       custom_areas = {
          right = function()


### PR DESCRIPTION
Tiny change: the correct setting is `nvim_lsp` with an underscore, not a hyphen.

https://github.com/akinsho/bufferline.nvim#lsp-indicators