### PR TITLE
fix: spelling in the example files

### DIFF
--- a/lua/custom/example_chadrc.lua
+++ b/lua/custom/example_chadrc.lua
@@ -8,7 +8,7 @@ M.options, M.ui, M.mappings, M.plugins = {}, {}, {}, {}
 
 --------------------------------------------------------------------
 
--- To use this file, copy the strucutre of `core/default_config.lua`,
+-- To use this file, copy the structure of `core/default_config.lua`,
 -- examples of setting relative number & changing theme:
 
 -- M.options = {

--- a/lua/custom/example_init.lua
+++ b/lua/custom/example_init.lua
@@ -1,4 +1,4 @@
--- This is where you custom modules and plugins goes.
+-- This is where your custom modules and plugins goes.
 -- See the wiki for a guide on how to extend NvChad
 
 local hooks = require "core.hooks"


### PR DESCRIPTION
Changed the spelling of "structure" in example_chadrc.lua and fixed a grammatical error in example_init.lua.
It was driving my ocd nuts.