### PR TITLE
fix: use of left/right arrow keys in insert mode

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -45,7 +45,7 @@ opt.updatetime = options.updatetime
 
 -- go to previous/next line with h,l,left arrow and right arrow
 -- when cursor reaches end/beginning of line
-opt.whichwrap:append "<>hl"
+opt.whichwrap:append "<>[]hl"
 
 g.mapleader = options.mapleader
 


### PR DESCRIPTION
This allows the left and right arrows to move between lines in insert mode. Earlier it only worked in normal mode.