### PR TITLE
update nvim-cmp plugin

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -43,22 +43,18 @@ cmp.setup {
          select = true,
       },
       ["<Tab>"] = function(fallback)
-         if cmp.visible() then
-            cmp.select_next_item()
-         elseif require("luasnip").expand_or_jumpable() then
-            vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-expand-or-jump", true, true, true), "")
-         else
-            fallback()
-         end
+        if cmp.visible() then
+          cmp.select_next_item()
+        else
+          fallback()
+        end
       end,
       ["<S-Tab>"] = function(fallback)
-         if cmp.visible() then
-            cmp.select_prev_item()
-         elseif require("luasnip").jumpable(-1) then
-            vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-jump-prev", true, true, true), "")
-         else
-            fallback()
-         end
+        if cmp.visible() then
+          cmp.select_prev_item()
+        else
+          fallback()
+        end
       end,
    },
    sources = {


### PR DESCRIPTION
Follow [this](https://github.com/hrsh7th/nvim-cmp/issues/231) breaking change of `nvim-cmp`

We need to run `PackerUpdate` after updating this config.