### PR TITLE
Add nvim-ts-context-commentstring

### DIFF
--- a/lua/plugins/configs/others.lua
+++ b/lua/plugins/configs/others.lua
@@ -68,7 +68,11 @@ end
 M.comment = function()
    local present, nvim_comment = pcall(require, "nvim_comment")
    if present then
-      nvim_comment.setup()
+      nvim_comment.setup {
+         hook = function()
+            require("ts_context_commentstring.internal").update_commentstring()
+         end,
+      }
    end
 end
 

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -11,4 +11,8 @@ ts_config.setup {
       enable = true,
       use_languagetree = true,
    },
+   context_commentstring = {
+      enable = true,
+      enable_autocmd = false,
+   },
 }

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -228,6 +228,13 @@ return packer.startup(function()
       end,
    }
 
+   use {
+      "JoosepAlviste/nvim-ts-context-commentstring",
+      disable = not status.comment,
+      before = "nvim-comment",
+      after = "nvim-treesitter",
+   }
+
    -- file managing , picker etc
    use {
       "kyazdani42/nvim-tree.lua",


### PR DESCRIPTION
Svelte, Vue, and others (think languages with DSL, etc.) have multiple
comment types per file (Svelte: HTML/CSS/JS+TS). nvim-comment is
basically useless in those files without nvim-ts-context-commentstring.

Signed-off-by: Andrew Balmos <andrew@balmos.org>