### PR TITLE
Add NvimTreeFindFileToggle as cmd

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -201,7 +201,7 @@ local default_plugins = {
   -- file managing , picker etc
   {
     "nvim-tree/nvim-tree.lua",
-    cmd = { "NvimTreeToggle", "NvimTreeFocus" },
+    cmd = { "NvimTreeToggle", "NvimTreeFocus", "NvimTreeFindFileToggle" },
     init = require("core.utils").load_mappings "nvimtree",
     opts = function()
       return require "plugins.configs.nvimtree"


### PR DESCRIPTION
[`NvimTreeFindFileToggle`](https://github.com/nvim-tree/nvim-tree.lua/blob/master/doc/nvim-tree-lua.txt#L150) opens the tree with the current file selected, so I like it more than NvimTreeToggle. The issue is that when you open nvim, the command isn't available on startup. cmd isn't configurable, so it'd be great if we could add the command for everyone