### PR TITLE
fix(cmp): lsp suggestions before snippets

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -105,8 +105,8 @@ local options = {
     }),
   },
   sources = {
-    { name = "luasnip" },
     { name = "nvim_lsp" },
+    { name = "luasnip" },
     { name = "buffer" },
     { name = "nvim_lua" },
     { name = "path" },


### PR DESCRIPTION
<h1 align="center">fix(cmp): lsp suggestions before snippets</h1>

## Problem

I recently encountered an issue when coding in TypeScript where I was having trouble accessing the fields of a structure. Whenever I pressed \<C-Space\>, it displayed all the code snippets before the fields, making it difficult to locate the specific information I needed. 

## Solution

I was able to bypass this by giving higher priority to the LSP over the code snippets.

```diff
  sources = {
-    { name = "luasnip" },
     { name = "nvim_lsp" },
+    { name = "luasnip" },
```

## Considerations

If you believe that the current behavior is not aligned with your expectations or requirements, please feel free to make any necessary corrections or simply disregard the current submission.

---

Best Regards,
Daniel Boll. 🎴