### PR TITLE
feat(bootstrap): indicate that no is the default answer

### DIFF
--- a/lua/core/bootstrap.lua
+++ b/lua/core/bootstrap.lua
@@ -48,7 +48,7 @@ end
 M.gen_chadrc_template = function()
   if not vim.api.nvim_get_runtime_file("lua/custom/chadrc.lua", false)[1] then
     local path = vim.fn.stdpath "config" .. "/lua/custom/"
-    local input = vim.fn.input "Do you want to install example custom config? (y/n) : "
+    local input = vim.fn.input "Do you want to install example custom config? (y/N) : "
 
     if input == "y" then
       M.echo "cloning example custom config repo ..."


### PR DESCRIPTION
<h1 align="center"> feat(bootstrap): indicate that no is the default answer </h1>

Indicates that the default answer would be *no* if the user provide any input other than `y`

```diff
- local input = vim.fn.input "Do you want to install example custom config? (y/n) : "
+ local input = vim.fn.input "Do you want to install example custom config? (y/N) : "
```