### PR TITLE
gitsign: handling file path with spaces

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -101,7 +101,7 @@ local default_plugins = {
       vim.api.nvim_create_autocmd({ "BufRead" }, {
         group = vim.api.nvim_create_augroup("GitSignsLazyLoad", { clear = true }),
         callback = function()
-          vim.fn.system("git -C " .. vim.fn.expand "%:p:h" .. " rev-parse")
+          vim.fn.system("git -C " .. '"' .. vim.fn.expand "%:p:h" .. '"' .. " rev-parse")
           if vim.v.shell_error == 0 then
             vim.api.nvim_del_augroup_by_name "GitSignsLazyLoad"
             vim.schedule(function()


### PR DESCRIPTION
the git file was failing if there was an ancestor directory with space