### PR TITLE
fix(mappings): fix description of j key in x mode

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -57,7 +57,7 @@ M.general = {
   },
 
   x = {
-    ["j"] = { 'v:count || mode(1)[0:1] == "no" ? "j" : "gj"', "move left", opts = { expr = true } },
+    ["j"] = { 'v:count || mode(1)[0:1] == "no" ? "j" : "gj"', "move up", opts = { expr = true } },
     ["k"] = { 'v:count || mode(1)[0:1] == "no" ? "k" : "gk"', "move down", opts = { expr = true } },
     -- Don't copy the replaced text after pasting in visual mode
     -- https://vim.fandom.com/wiki/Replace_a_word_with_yanked_text#Alternative_mapping_for_paste


### PR DESCRIPTION
Hi, this is my first PR in this repository.
When viewing the default mappings in the config, I noticed that the j key had a description of "move left" while the k key had a description of "move down". So I figured there may have been a mismatch and have changed the description of j key back to "move up".
If my PR format has any problem, please let me know!
Thank you