### PR TITLE
fix: readme links

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -3,13 +3,13 @@
 <div align="center">
 	<a href="https://nvchad.com/">Home</a>
   <span> • </span>
-    	<a href="https://nvchad.com/#/docs/quickstart/install">Install</a>
+    	<a href="https://nvchad.com/docs/quickstart/install">Install</a>
   <span> • </span>
-       	<a href="https://nvchad.com/#/docs/contribute">Contribute</a>
+       	<a href="https://nvchad.com/docs/contribute">Contribute</a>
   <span> • </span>
 	<a href="https://github.com/NvChad/NvChad#gift_heart-support">Support</a>
   <span> • </span>
-        <a href="https://nvchad.com/#/docs/features">Features</a>
+        <a href="https://nvchad.com/docs/features">Features</a>
   <p></p>
 </div> 
 


### PR DESCRIPTION
This PR removes the `#/` part that might have been introduced from this commit https://github.com/NvChad/NvChad/commit/11f30badfaf0e8861926aee8bf9ee7b0785f469c in some of the links.
This was causing issues when clicking the links from the README, now they are working properly. 