### PR TITLE
Update core/init.lua,  Putting .../mason/bin/ at the beginning of vim.env.PATH

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -58,7 +58,7 @@ end
 
 -- add binaries installed by mason.nvim to path
 local is_windows = vim.loop.os_uname().sysname == "Windows_NT"
-vim.env.PATH = vim.env.PATH .. (is_windows and ";" or ":") .. vim.fn.stdpath "data" .. "/mason/bin"
+vim.env.PATH = vim.fn.stdpath "data" .. "/mason/bin" .. (is_windows and ";" or ":") .. vim.env.PATH
 
 -------------------------------------- autocmds ------------------------------------------
 local autocmd = vim.api.nvim_create_autocmd


### PR DESCRIPTION
Putting `.../mason/bin/` in the beginning of `vim.env.PATH`

There is an [issue](https://github.com/williamboman/mason.nvim/issues/1289#issue-1699178332) with `rust_analyzer`, a mason plugin, not loading properly on macos ventura, neovim setup with NvChad default configs.
`.../mason/bin/` is added at end of `vim.env.PATH`,  causing a broken `rust-analyzer` from **~/.cargo/bin** being loaded first.

I propose this change to search mason/bin first for plugins