### PR TITLE
Consistent border style when navigating diagnostics

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -193,14 +193,14 @@ M.lspconfig = {
 
     ["[d"] = {
       function()
-        vim.diagnostic.goto_prev()
+        vim.diagnostic.goto_prev({ float = { border = "rounded" }})
       end,
       "Goto prev",
     },
 
     ["]d"] = {
       function()
-        vim.diagnostic.goto_next()
+        vim.diagnostic.goto_next({ float = { border = "rounded" }})
       end,
       "Goto next",
     },


### PR DESCRIPTION
When navigating using `goto_next` and `goto_prev` the default borderless style is used but when opening the floating diagnostic the rounded border is used (which is nicer).

To keep consistency I passed the border style to the methods, but the same could be achieved with:

```lua
vim.diagnostic.config({ float = { border = "rounded" } })
```

This changes the global config so it will work even if the `goto_next` is called manually.

I'm not sure which branch I should ask the PR for so i'm going with the HEAD.