### PR TITLE
- add 'nvim-osc52' plugin, support neovim clipboard and ssh copy.

### DIFF
--- a/lua/plugins/configs/osc52.lua
+++ b/lua/plugins/configs/osc52.lua
@@ -1,0 +1,36 @@
+-- https://github.com/ojroques/nvim-osc52
+--
+require("osc52").setup()
+
+-- local function copy2()
+-- 	if vim.v.event.operator == 'y' and vim.v.event.regname == '+' then
+-- 		require('osc52').copy_register('+')
+-- 	end
+-- end
+--
+-- vim.api.nvim_create_autocmd('TextYankPost', {
+-- 	callback = copy2,
+-- })
+
+local function copy(lines, _)
+	require('osc52').copy(table.concat(lines, '\n'))
+end
+
+local function paste()
+	return {
+		vim.fn.split(vim.fn.getreg(''), '\n'),
+		vim.fn.getregtype(''),
+	}
+end
+
+vim.g.clipboard = {
+	name = 'osc52',
+	copy = {
+		['+'] = copy,
+		['*'] = copy,
+	},
+	paste = {
+		['+'] = paste,
+		['*'] = paste,
+	},
+}

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -92,6 +92,14 @@ local default_plugins = {
     end,
   },
 
+  {
+    "ojroques/nvim-osc52",
+	 lazy = false,
+    config = function()
+      require "plugins.configs.osc52"
+    end,
+  },
+
   -- git stuff
   {
     "lewis6991/gitsigns.nvim",


### PR DESCRIPTION
`nvim-osc52` is a lua plugin, which support neovim clipboard and ssh remote copy.

clipboard support, check line 74-75
<img width="870" alt="Screenshot 2023-05-22 at 10 29 24" src="https://github.com/NvChad/NvChad/assets/1501146/772be470-5bd2-4942-bd16-d989eb12acd8">

yank multiple lines result, yank line  13~17, check the bottom message.
<img width="980" alt="Screenshot 2023-05-22 at 10 28 59" src="https://github.com/NvChad/NvChad/assets/1501146/01988dcb-3047-4df1-8d99-556a0a5676e4">
