### PR TITLE
allow to override default config of comment.nvim

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -204,8 +204,8 @@ local default_plugins = {
     init = function()
       require("core.utils").load_mappings "comment"
     end,
-    config = function()
-      require("Comment").setup()
+    config = function(_, opts)
+      require("Comment").setup(opts)
     end,
   },
 


### PR DESCRIPTION
In order to allow to override the comment.nvim setup options using the `opts` property of lazy.nvim just like all other plugins.

Otherwise it is not possible to override the options without overriding the `config` prop by yourself.