### PR TITLE
Update in init.lua on line no. 77

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -74,7 +74,7 @@ autocmd("FileType", {
 -- reload some chadrc options on-save
 vim.api.nvim_create_autocmd("BufWritePost", {
   pattern = vim.tbl_map(
-    vim.fs.normalize,
+    vim.fn.normalize,
     vim.fn.glob(vim.fn.stdpath "config" .. "/lua/custom/**/*.lua", true, true, true)
   ),
   group = vim.api.nvim_create_augroup("ReloadNvChad", {}),


### PR DESCRIPTION
On line no. 77 instead of vim.fs.normalize it should be vim.fn.normalize This was causing me this error: 
Error detected while processing /home/terminator/.config/nvim/init.lua: E5113: Error while calling lua chunk: /home/terminator/.config/nvim/lua/core/init.lua:77: attem pt to index field 'fs' (a nil value)
stack traceback:
        /home/terminator/.config/nvim/lua/core/init.lua:77: in main chunk
        [C]: in function 'require'
        /home/terminator/.config/nvim/init.lua:1: in main chunk