### PR TITLE
Fix Comment.nvim not loading in visual mode

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -200,7 +200,12 @@ local default_plugins = {
 
   {
     "numToStr/Comment.nvim",
-    keys = { "gcc", "gbc" },
+    keys = { 
+      { "gcc", mode = 'n' }
+      { "gbc", mode = 'n' },
+      { "gc", mode = 'v' },
+      { "gb", mode = 'v' },
+    }
     init = function()
       require("core.utils").load_mappings "comment"
     end,


### PR DESCRIPTION
Adds all required mappings to commenting stuff in and out (incl. from visual mode), to properly lazy load Comments.nvim.