### PR TITLE
Fix missing commas

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -201,11 +201,11 @@ local default_plugins = {
   {
     "numToStr/Comment.nvim",
     keys = { 
-      { "gcc", mode = 'n' }
+      { "gcc", mode = 'n' },
       { "gbc", mode = 'n' },
       { "gc", mode = 'v' },
       { "gb", mode = 'v' },
-    }
+    },
     init = function()
       require("core.utils").load_mappings "comment"
     end,


### PR DESCRIPTION
Well, there are missing commas in "lua/plugins/init.lua"

I don't know if the missing commas have any impact on other OS. But it gives some errors on Windows.

Error: 
```
E5113: Error while calling lua chunk: vim/_init_packages.lua:21: C:\Users\user\AppData\Local\nvim/lua/plugins/init.lua:205: '}' expected (to close '{' at line 203) near '{'
stack traceback:
        [C]: in function 'error'
        vim/_init_packages.lua:21: in function <vim/_init_packages.lua:15>
        [C]: in function 'require'
        C:\Users\user\AppData\Local\nvim\init.lua:21: in main chunk
```