### PR TITLE
Change `Tab` cmp behaviour

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -81,7 +81,7 @@ local options = {
     },
     ["<Tab>"] = cmp.mapping(function(fallback)
       if cmp.visible() then
-        cmp.select_next_item()
+        cmp.select_next_item({ behavior = cmp.SelectBehavior.Select })
       elseif require("luasnip").expand_or_jumpable() then
         vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-expand-or-jump", true, true, true), "")
       else
@@ -93,7 +93,7 @@ local options = {
     }),
     ["<S-Tab>"] = cmp.mapping(function(fallback)
       if cmp.visible() then
-        cmp.select_prev_item()
+        cmp.select_prev_item({ behavior = cmp.SelectBehavior.Select })
       elseif require("luasnip").jumpable(-1) then
         vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-jump-prev", true, true, true), "")
       else


### PR DESCRIPTION
The default tab behavior of `nvim-cmp` is to only select not insert the suggestion on arrow movement.
However, since `NvChad` doesn't map `up` and `down` arrow keys `<C-n` and `<C-p>` work the same as `<Tab>` and `<S-Tab>`.

Different keys for the same action should be avoided so, having the `Tab` keys work the same as arrow keys seems like the more acceptable way.