### PR TITLE
telescope: Explicitly depend on nvim-treesitter

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -233,6 +233,7 @@ local default_plugins = {
 
   {
     "nvim-telescope/telescope.nvim",
+    dependencies = "nvim-treesitter/nvim-treesitter",
     cmd = "Telescope",
     init = function()
       require("core.utils").load_mappings "telescope"


### PR DESCRIPTION
Fix Telescope syntax highlighting is not working until open a file https://github.com/NvChad/NvChad/issues/2084