### PR TITLE
fix: change minimum nvim version

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -15,7 +15,7 @@
 
 <div align="center">
  
-[![Neovim Minimum Version](https://img.shields.io/badge/Neovim-0.8.3-blueviolet.svg?style=flat-square&logo=Neovim&color=90E59A&logoColor=white)](https://github.com/neovim/neovim)
+[![Neovim Minimum Version](https://img.shields.io/badge/Neovim-0.9.0-blueviolet.svg?style=flat-square&logo=Neovim&color=90E59A&logoColor=white)](https://github.com/neovim/neovim)
 [![GitHub Issues](https://img.shields.io/github/issues/NvChad/NvChad.svg?style=flat-square&label=Issues&color=d77982)](https://github.com/NvChad/NvChad/issues)
 [![Discord](https://img.shields.io/discord/869557815780470834?color=738adb&label=Discord&logo=discord&logoColor=white&style=flat-square)](https://discord.gg/gADmkJb9Fb)
 [![Matrix](https://img.shields.io/badge/Matrix-40aa8b.svg?style=flat-square&logo=Matrix&logoColor=white)](https://matrix.to/#/#nvchad:matrix.org)


### PR DESCRIPTION
First of all, thanks for the nice config! I started using it today and I liked it a lot.
An Issue that I ran into today was, that I had neovim `v0.8.3` installed, which wasn't new enough for `telescope.nvim`. They state following in their readme:
> Neovim (v0.9.0) or the latest neovim nightly commit is required for telescope.nvim to work.

I just wanted to "fix" the readme, as nvim 0.9.0 or upwards is needed for nvchad to work.