### PR TITLE
feat: update cmp.lua to remove tab binds

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -79,30 +79,6 @@ local options = {
       behavior = cmp.ConfirmBehavior.Insert,
       select = true,
     },
-    ["<Tab>"] = cmp.mapping(function(fallback)
-      if cmp.visible() then
-        cmp.select_next_item()
-      elseif require("luasnip").expand_or_jumpable() then
-        vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-expand-or-jump", true, true, true), "")
-      else
-        fallback()
-      end
-    end, {
-      "i",
-      "s",
-    }),
-    ["<S-Tab>"] = cmp.mapping(function(fallback)
-      if cmp.visible() then
-        cmp.select_prev_item()
-      elseif require("luasnip").jumpable(-1) then
-        vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-jump-prev", true, true, true), "")
-      else
-        fallback()
-      end
-    end, {
-      "i",
-      "s",
-    }),
   },
   sources = {
     { name = "nvim_lsp" },


### PR DESCRIPTION
Tab and Shift tab being bound to swapping trough the suggestions is pretty annoying, so maybe we change it to be voluntary instead of default?
I had to do [this](https://github.com/aneshodza/nvchad_config/blob/eaf1f41626afcec03ac91aad1a45444c0e0ace9d/configs/overrides.lua#L77) to fix it.