### PR TITLE
Defaulting to not installing custom config in --headless mode

### DIFF
--- a/lua/core/bootstrap.lua
+++ b/lua/core/bootstrap.lua
@@ -34,6 +34,7 @@ M.gen_chadrc_template = function()
   if not vim.api.nvim_get_runtime_file("lua/custom/chadrc.lua", false)[1] then
     local path = vim.fn.stdpath "config" .. "/lua/custom/"
     local input = "N"
+
     if next(vim.api.nvim_list_uis()) then
       input = vim.fn.input "Do you want to install example custom config? (y/N) : "
     end

--- a/lua/core/bootstrap.lua
+++ b/lua/core/bootstrap.lua
@@ -33,7 +33,10 @@ end
 M.gen_chadrc_template = function()
   if not vim.api.nvim_get_runtime_file("lua/custom/chadrc.lua", false)[1] then
     local path = vim.fn.stdpath "config" .. "/lua/custom/"
-    local input = vim.fn.input "Do you want to install example custom config? (y/N) : "
+    local input = "N"
+    if next(vim.api.nvim_list_uis()) then
+      input = vim.fn.input "Do you want to install example custom config? (y/N) : "
+    end
 
     -- clone example_config repo
     if input == "y" then


### PR DESCRIPTION
This solves the issue I was mentioning [here](https://github.com/NvChad/NvChad/discussions/2131) in discussions.

So it's possible now to install nvchad without interaction with a user.

Here is how I did it using this fork:

```
git clone https://github.com/hexdigest/NvChad ~/.config/nvim --depth 1
nvim --headless +"sleep 30" +qa
```
Here I run nvchad installation and give it 30 seconds to install. 