### PR TITLE
fix: make key mapping's description to lazy load Comment.nvim coherent with the defaults

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -201,10 +201,12 @@ local default_plugins = {
   {
     "numToStr/Comment.nvim",
     keys = {
-      { "gcc", mode = "n", desc = "Toggles comment on current line" },
-      { "gc", mode = { "n", "o", "x" }, desc = "Toggles comment on current line's region" },
-      { "gbc", mode = "n", desc = "Toggles blockwise comment on current line" },
-      { "gb", mode = { "n", "o", "x" }, desc = "Toggles blockwise comment on region" },
+      { "gcc", mode = "n", desc = "Comment toggle current line" },
+      { "gc", mode = { "n", "o" }, desc = "Comment toggle linewise" },
+      { "gc", mode = "x", desc = "Comment toggle linewise (visual)" },
+      { "gbc", mode = "n", desc = "Comment toggle current block" },
+      { "gb", mode = { "n", "o" }, desc = "Comment toggle blockwise" },
+      { "gb", mode = "x", desc = "Comment toggle blockwise (visual)" },
     },
     init = function()
       require("core.utils").load_mappings "comment"


### PR DESCRIPTION
The descriptions of `gcc`, `gc`, `gb`, `gbc` on first run didn't correspond to the defaults. See : 
[https://github.com/numToStr/Comment.nvim/blob/master/plugin/Comment.lua](https://github.com/numToStr/Comment.nvim/blob/master/plugin/Comment.lua)
[https://github.com/numToStr/Comment.nvim/blob/master/lua/Comment/init.lua](https://github.com/numToStr/Comment.nvim/blob/master/lua/Comment/init.lua)

If you approve my pull request, my three consecutive commits might be melded into one (eg : "Improve keys property for Comment.vim"). 
Sorry for not having thought about it more thoroughly before.