### PR TITLE
fix: wildcard pattern usage in `fs_realpath`

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -72,11 +72,10 @@ autocmd("FileType", {
 })
 
 -- reload some chadrc options on-save
-vim.api.nvim_create_autocmd("BufWritePost", {
-  pattern = vim.tbl_map(
-    vim.fs.normalize,
-    vim.fn.glob(vim.loop.fs_realpath(vim.fn.stdpath "config" .. "/lua/custom/**/*.lua"), true, true, true)
-  ),
+autocmd("BufWritePost", {
+  pattern = vim.tbl_map(function(path)
+    return vim.fs.normalize(vim.loop.fs_realpath(path))
+  end, vim.fn.glob(vim.fn.stdpath "config" .. "/lua/custom/**/*.lua", true, true, true)),
   group = vim.api.nvim_create_augroup("ReloadNvChad", {}),
 
   callback = function(opts)


### PR DESCRIPTION
Normally `fs_realpath` accepts only a filename and `realpath` itself cannot handle wildcard expansion. 