### PR TITLE
Add mapping for LSP formatting command

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -32,7 +32,8 @@ M.general = {
     -- line numbers
     ["<leader>n"] = { "<cmd> set nu! <CR>", "Toggle line number" },
     ["<leader>rn"] = { "<cmd> set rnu! <CR>", "Toggle relative number" },
-
+    --LSP formatting
+    ["<leader>fm"] = { "<cmd> lua vim.lsp.buf.format() <CR>", "LSP formatting"},
     -- Allow moving the cursor through wrapped lines with j, k, <Up> and <Down>
     -- http://www.reddit.com/r/vim/comments/2k4cbr/problem_with_gj_and_gk/
     -- empty mode is same as using <cmd> :map


### PR DESCRIPTION
The specific change made:
- Added a mapping for the LSP formatting command ("<leader>fm") to invoke the "vim.lsp.buf.format()" function.
- The default mapping was not working, so this custom mapping was added to ensure the functionality is available.