### PR TITLE
Pull Request: Allow Customization of "mason/bin" Path Handling

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -83,12 +83,9 @@ M.ui = {
   },
 }
 
--- Where NvChad should put mason.nvim bin location in your PATH. Can be one of:
--- - "prepend" (default, Mason's bin location is put first in PATH)
--- - "append" (Mason's bin location is put at the end of PATH)
--- - "skip" (doesn't modify PATH)
+-- Determines the preferred placement of the mason.nvim bin directory in your PATH.
 ---@type '"prepend"' | '"append"' | '"skip"'
-M.mason_path = "prepend"
+M.place_mason_bin = "prepend"
 
 M.plugins = "" -- path i.e "custom.plugins", so make custom/plugins.lua file
 

--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -83,6 +83,13 @@ M.ui = {
   },
 }
 
+-- Where NvChad should put mason.nvim bin location in your PATH. Can be one of:
+-- - "prepend" (default, Mason's bin location is put first in PATH)
+-- - "append" (Mason's bin location is put at the end of PATH)
+-- - "skip" (doesn't modify PATH)
+---@type '"prepend"' | '"append"' | '"skip"'
+M.mason_path = "prepend"
+
 M.plugins = "" -- path i.e "custom.plugins", so make custom/plugins.lua file
 
 M.lazy_nvim = require "plugins.configs.lazy_nvim" -- config for lazy.nvim startup options

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -58,7 +58,11 @@ end
 
 -- add binaries installed by mason.nvim to path
 local is_windows = vim.loop.os_uname().sysname == "Windows_NT"
-vim.env.PATH = vim.fn.stdpath "data" .. "/mason/bin" .. (is_windows and ";" or ":") .. vim.env.PATH
+if config.mason_path == "prepend" then
+  vim.env.PATH = vim.fn.stdpath "data" .. "/mason/bin" .. (is_windows and ";" or ":") .. vim.env.PATH
+elseif config.mason_path == "append" then
+  vim.env.PATH = vim.env.PATH .. (is_windows and ";" or ":") .. vim.fn.stdpath "data" .. "/mason/bin"
+end
 
 -------------------------------------- autocmds ------------------------------------------
 local autocmd = vim.api.nvim_create_autocmd

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -57,11 +57,15 @@ for _, provider in ipairs { "node", "perl", "python3", "ruby" } do
 end
 
 -- add binaries installed by mason.nvim to path
+-- based on the selected 'place_mason_bin' option
 local is_windows = vim.loop.os_uname().sysname == "Windows_NT"
-if config.mason_path == "prepend" then
-  vim.env.PATH = vim.fn.stdpath "data" .. "/mason/bin" .. (is_windows and ";" or ":") .. vim.env.PATH
-elseif config.mason_path == "append" then
-  vim.env.PATH = vim.env.PATH .. (is_windows and ";" or ":") .. vim.fn.stdpath "data" .. "/mason/bin"
+local path_separator = is_windows and ";" or ":"
+local mason_bin_path = vim.fn.stdpath "data" .. "/mason/bin"
+
+if config.place_mason_bin == "prepend" then
+  vim.env.PATH = mason_bin_path .. path_separator .. vim.env.PATH
+elseif config.place_mason_bin == "append" then
+  vim.env.PATH = vim.env.PATH .. path_separator .. mason_bin_path
 end
 
 -------------------------------------- autocmds ------------------------------------------

--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -1,6 +1,10 @@
 local options = {
   ensure_installed = { "lua-language-server" }, -- not an option from mason.nvim
 
+-- Note: Avoid setting `PATH="prepend"|"append"` here.
+-- To change the location of the mason/bin directory, update the 'place_mason_bin' option
+-- in 'custom/chadrc.lua'. If you must set it here, ensure 'place_mason_bin' in 'custom/chadrc.lua'
+-- is set to 'skip' to prevent duplicate mason/bin paths.
   PATH = "skip",
 
   ui = {


### PR DESCRIPTION
## Pull Request: Allow Customization of "mason/bin" Path Handling

### Description
This pull request introduces a new feature that allows users to customize the handling of the "mason/bin" path in the system. The change is achieved by adding the `place_mason_bin` option to the [`custom/chadrc.lua` file][1]. Users can now choose whether to prepend or append the "mason/bin" path based on their specific needs.

I have set the default option to prepend, aligning with the existing setting used in [`mason.nvim`][2] for consistency.

This change was prompted by a [discussion][3] regarding the need for more flexibility in managing the "mason/bin" path.

### Request
I kindly request a thorough review and verification of this pull request. Your feedback and suggestions are highly appreciated. Thank you!

[1]:https://github.com/TirtharajPramanik/example_config/blob/d19060f029642f039604d2de12b91270c0e52720/chadrc.lua#L15C1-L21
[2]:https://github.com/williamboman/mason.nvim/blob/db58ec7bc9248fb1878172f90cadc825b77564a6/lua/mason/settings.lua#L10-L15
[3]:https://github.com/NvChad/NvChad/pull/2031#issuecomment-1606449443
