### PR TITLE
Use mason config option for PATH

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -56,10 +56,6 @@ for _, provider in ipairs { "node", "perl", "python3", "ruby" } do
   vim.g["loaded_" .. provider .. "_provider"] = 0
 end
 
--- add binaries installed by mason.nvim to path
-local is_windows = vim.loop.os_uname().sysname == "Windows_NT"
-vim.env.PATH = vim.fn.stdpath "data" .. "/mason/bin" .. (is_windows and ";" or ":") .. vim.env.PATH
-
 -------------------------------------- autocmds ------------------------------------------
 local autocmd = vim.api.nvim_create_autocmd
 

--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -1,7 +1,7 @@
 local options = {
   ensure_installed = { "lua-language-server" }, -- not an option from mason.nvim
 
-  PATH = "skip",
+  PATH = "prepend",
 
   ui = {
     icons = {

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -123,6 +123,7 @@ local default_plugins = {
   -- lsp stuff
   {
     "williamboman/mason.nvim",
+    lazy=false,
     cmd = { "Mason", "MasonInstall", "MasonInstallAll", "MasonUninstall", "MasonUninstallAll", "MasonLog" },
     opts = function()
       return require "plugins.configs.mason"


### PR DESCRIPTION
This PR removes the PATH manipulation in `core/init.lua` that puts the `mason/bin` path onto users' `PATH` which can mask or even override the user's specified config in `custom/plugins.lua`.

Instead, the plugin's builtin `PATH` option is leveraged, which is in better alignment with how every other plugin is configured (default config is overridden by/merged wth user `custom` config).

To accomplish this, this PR also loads mason eagerly (i.e. `lazy=false`) so that the path is always updated in the manner requested by the user.