### PR TITLE
accessibility to customize telescope.nvim

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -27,7 +27,13 @@ M.ui = {
     selected_item_bg = "colored", -- colored / simple
   },
 
-  telescope = { style = "borderless" }, -- borderless / bordered
+  telescope = {
+    style = "borderless", -- borderless / bordered
+    --  see https://github.com/NvChad/NvChad/blob/v2.0/lua/plugins/configs/telescope.lua
+    --  and telescope.nvim docs to customize it
+    -- nil / table
+    options = nil,
+  },
 
   ------------------------------- nvchad_ui modules -----------------------------
   statusline = {

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -242,7 +242,12 @@ local default_plugins = {
       require("core.utils").load_mappings "telescope"
     end,
     opts = function()
-      return require "plugins.configs.telescope"
+      local options = require("core.utils").load_config().ui.telescope.options
+      local default_options = require "plugins.configs.telescope"
+      if options then
+        return vim.tbl_deep_extend("force", default_options, options)
+      end
+      return default_options
     end,
     config = function(_, opts)
       dofile(vim.g.base46_cache .. "telescope")


### PR DESCRIPTION
when I was configuring `NvChad`, I notice that `telescope.nvim` is missing a customization filed and it doesn't have examples how to customize it in the doc [website](https://nvchad.com/docs) and its seems `NvChad` missed this feature, so I made some touches to let the user customizing it easily.
for ex: I want to disable find files preview in `telescope.nvim` , I can't do it in `NvChad` (i searched for this and i found nothing)
with the touches I made, you can configure it by set `options` (its a new filed) filed in `telescope` property in `chadrc.lua`:
```lua
M.ui = {
 -...
telescope = {
 style = "borderd"
 -- beside `style` filed
 options = {
-- see https://github.com/nvim-telescope/telescope.nivm docs
  pickers = {
   find_files = {
    previewer = false, 
  }
  }
-...
```
in that way we can now customizing it with the way we want