### PR TITLE
fix(icon): replace find icon with f021e

### DIFF
--- a/lua/core/default_config.lua
+++ b/lua/core/default_config.lua
@@ -63,7 +63,7 @@ M.ui = {
     },
 
     buttons = {
-      { "  Find File", "Spc f f", "Telescope find_files" },
+      { "󰈞  Find File", "Spc f f", "Telescope find_files" },
       { "󰈚  Recent Files", "Spc f o", "Telescope oldfiles" },
       { "󰈭  Find Word", "Spc f w", "Telescope live_grep" },
       { "  Bookmarks", "Spc m a", "Telescope marks" },


### PR DESCRIPTION
The previous find fine icon does not work in iTerm2 even if using nerd font. Replacing it with f021e
After fix:
<img width="444" alt="image" src="https://github.com/NvChad/NvChad/assets/8992564/95487237-1b04-471d-8e1f-ca8e70597391">
Before fix:
<img width="460" alt="image" src="https://github.com/NvChad/NvChad/assets/8992564/67c1a586-9328-4ecc-8bee-22846db21b51">
