### PR TITLE
fix: support fetching submodules to get nvchad_types

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -16,6 +16,7 @@ local default_plugins = {
     "NvChad/ui",
     branch = "v2.0",
     lazy = false,
+    submodules = true,
   },
 
   {


### PR DESCRIPTION
Hi! now that nvchad_types are in a separated repo https://github.com/NvChad/lua_types/ adding submodules = true will fetch nvchad_types so that we can include it in our lsp settings as 

```lua
...
{
  settings = {
    Lua = {
      workspace = {
        library = { vim.fn.stdpath "data" .. "/lazy/ui/nvchad_types" }
      }
    }
  }
}
```