### PR TITLE
updated telescope search glyph from nf-mdi-magnify (removed in nerdfo…

### DIFF
--- a/lua/plugins/configs/telescope.lua
+++ b/lua/plugins/configs/telescope.lua
@@ -10,7 +10,7 @@ local options = {
       "--column",
       "--smart-case",
     },
-    prompt_prefix = "   ",
+    prompt_prefix = " 󰍉 ",
     selection_caret = "  ",
     entry_prefix = "  ",
     initial_mode = "insert",


### PR DESCRIPTION
updated telescope search glyph from nf-mdi-magnify (removed in nerdfonts v3.0.0) to nf-md-magnify 󰍉, same icon, new codepoint 

fixes issue #2305