### PR TITLE
feat: updated lazygit keys for which-key plugin

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -252,7 +252,7 @@ local default_plugins = {
   -- Only load whichkey after all the gui
   {
     "folke/which-key.nvim",
-    keys = { "<leader>", '"', "'", "`", "c", "v", "g" },
+    keys = { "<leader>", "<c-r>", '"', "'", "`", "c", "v", "g" },
     init = function()
       require("core.utils").load_mappings "whichkey"
     end,


### PR DESCRIPTION
For whichkey the `<c-r>` lazyload keybinding was missing.