### PR TITLE
Remove mappings feature

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -87,6 +87,33 @@ M.load_mappings = function(section, mapping_opt)
   end)
 end
 
+M.remove_mappings = function(section)
+  vim.schedule(function()
+    local function remove_section_map(section_values)
+      if section_values.plugin then
+        return
+      end
+
+      for mode, mode_values in pairs(section_values) do
+        for keybind, _ in pairs(mode_values) do
+          local _, _ = pcall(vim.api.nvim_del_keymap, mode, keybind)
+        end
+      end
+    end
+
+    local mappings = require("core.utils").load_config().mappings
+
+    if type(section) == "string" then
+      mappings[section]["plugin"] = nil
+      mappings = { mappings[section] }
+    end
+
+    for _, sect in pairs(mappings) do
+      remove_section_map(sect)
+    end
+  end)
+end
+
 M.lazy_load = function(plugin)
   vim.api.nvim_create_autocmd({ "BufRead", "BufWinEnter", "BufNewFile" }, {
     group = vim.api.nvim_create_augroup("BeLazyOnFileOpen" .. plugin, {}),


### PR DESCRIPTION
Created this function so users can load/unload mappings on demand, this can be usefull when creating mappings for specific filetypes.

For example if you want a keybind to be available only in `go` filetype, you create your mapping with the `plugin` flag

```
M.go = {
  plugin = true,
  n = {
    ["<F1>"] = { "do something", "Text" },
  },
}
```

And to load/unload the keybind you can create an autocmd that will load and unload the mappings:

```
local autocmd = vim.api.nvim_create_autocmd
autocmd("FileType", {
  callback = function()
    if vim.bo.ft == "go" then
      require("core.utils").load_mappings "go"
    else
      require("core.utils").remove_mappings "go"
    end
  end,
})
```

In this way, we keep the record of the mappings in nvcheatsheet, maybe we can create a function to update nvcheatsheet if the mapping is loaded/unloaded?

I am creating this PR because I thought this could be usefull for others users  #1811, but I dont know if this can be improved or if there is another way to do it.