### PR TITLE
feat(lsp): add visual mode code actions

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -240,6 +240,15 @@ M.lspconfig = {
       "List workspace folders",
     },
   },
+
+  v = {
+    ["<leader>ca"] = {
+      function()
+        vim.lsp.buf.code_action()
+      end,
+      "LSP code action",
+    },
+  },
 }
 
 M.nvimtree = {


### PR DESCRIPTION
### V-mode code actions

Some LSP servers come with refactoring tools out of the box.
Actions like `move to function` only works in visual mode (e.g rust-analyzer)

I think this feature is generic enough to get added as a visual-mode keymapping
> [!NOTE]
> It's all built-in lsp server

### DEMO


https://github.com/NvChad/NvChad/assets/101834410/c0036e6e-b377-41bb-9b52-a7d122caf075

