### PR TITLE
performance: avoid reloading config

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -88,8 +88,7 @@ A fuzzy file finder, picker, sorter, previewer and much more:
 
 - Many beautiful themes, theme toggler by our [base46 plugin](https://github.com/NvChad/base46)
 - Inbuilt terminal toggling & management with [Nvterm](https://github.com/NvChad/nvterm)
-- NvChad updater, hide & unhide terminal buffers with [NvChad extensions](https://github.com/NvChad/extensions)
-- Lightweight & performant ui plugin with [NvChad UI](https://github.com/NvChad/ui) It provides statusline modules, tabufline ( tabs + buffer manager) , beautiful cheatsheets and much more!
+- Lightweight & performant ui plugin with [NvChad UI](https://github.com/NvChad/ui) It provides statusline modules, tabufline ( tabs + buffer manager) , beautiful cheatsheets, NvChad updater, hide & unhide terminal buffers, theme switcher and much more!
 - File navigation with [nvim-tree.lua](https://github.com/kyazdani42/nvim-tree.lua)
 - Beautiful and configurable icons with [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons)
 - Git diffs and more with [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim) 

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -1,6 +1,6 @@
 local opt = vim.opt
 local g = vim.g
-local config = require("core.utils").load_config()
+local config = require("core.utils").config
 
 -------------------------------------- globals -----------------------------------------
 g.nvchad_theme = config.ui.theme

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -7,10 +7,11 @@ M.load_config = function()
 
   if chadrc_path then
     local chadrc = dofile(chadrc_path)
-
-    config.mappings = M.remove_disabled_keys(chadrc.mappings, config.mappings)
-    config = merge_tb("force", config, chadrc)
-    config.mappings.disabled = nil
+    if chadrc then
+      config.mappings = M.remove_disabled_keys(chadrc.mappings, config.mappings)
+      config = merge_tb("force", config, chadrc)
+      config.mappings.disabled = nil
+    end
   end
 
   return config
@@ -51,6 +52,8 @@ M.remove_disabled_keys = function(chadrc_mappings, default_mappings)
   return default_mappings
 end
 
+M.config = M.load_config()
+
 M.load_mappings = function(section, mapping_opt)
   vim.schedule(function()
     local function set_section_map(section_values)
@@ -74,7 +77,7 @@ M.load_mappings = function(section, mapping_opt)
       end
     end
 
-    local mappings = require("core.utils").load_config().mappings
+    local mappings = require("core.utils").config.mappings
 
     if type(section) == "string" then
       mappings[section]["plugin"] = nil

--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -2,7 +2,7 @@ local cmp = require "cmp"
 
 dofile(vim.g.base46_cache .. "cmp")
 
-local cmp_ui = require("core.utils").load_config().ui.cmp
+local cmp_ui = require("core.utils").config.ui.cmp
 local cmp_style = cmp_ui.style
 
 local field_arrangement = {

--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -16,7 +16,7 @@ M.on_attach = function(client, bufnr)
     require("nvchad.signature").setup(client)
   end
 
-  if not utils.load_config().ui.lsp_semantic_tokens and client.supports_method "textDocument/semanticTokens" then
+  if not utils.config.ui.lsp_semantic_tokens and client.supports_method "textDocument/semanticTokens" then
     client.server_capabilities.semanticTokensProvider = nil
   end
 end

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -264,7 +264,7 @@ local default_plugins = {
   },
 }
 
-local config = require("core.utils").load_config()
+local config = require("core.utils").config
 
 if #config.plugins > 0 then
   table.insert(default_plugins, { import = config.plugins })


### PR DESCRIPTION
Each times `require("core.utils").load_config` is called, custom chadrc and custom mappings are merged with the default.
In particular, each call triggers the function `remove_disabled_keys` which merges the mappings.
I think it's not always necessary (excepting in the autocommand in `core.init.lua` which reloads some chadrc options on save), but maybe I'm wrong.
I propose these changes to solve this problem (use config as a property, not a method). The `config` property could perhaps be used in the `ui` repo too.
Below is a test which shows the number of calls before and after the changes.
## Before :
![nvchad_load_config1](https://github.com/NvChad/NvChad/assets/11246966/05ceb45e-921d-4447-9d4f-71e346b575ef)

## After :
![nvchad_load_config2](https://github.com/NvChad/NvChad/assets/11246966/1f07c342-bd48-433f-b5fc-defe6122c873)


_Note_: I've also added a test to avoid the case where the chadrc file was created but is empty (nil).
