### PR TITLE
add fzf telescope extension to improve sorting performance

### DIFF
--- a/lua/plugins/configs/telescope.lua
+++ b/lua/plugins/configs/telescope.lua
@@ -49,7 +49,7 @@ local options = {
     },
   },
 
-  extensions_list = { "themes", "terms" },
+  extensions_list = { "themes", "terms", "fzf" },
 }
 
 return options

--- a/lua/plugins/configs/telescope.lua
+++ b/lua/plugins/configs/telescope.lua
@@ -50,6 +50,14 @@ local options = {
   },
 
   extensions_list = { "themes", "terms", "fzf" },
+  extensions = {
+    fzf = {
+      fuzzy = true,
+      override_generic_sorter = true,
+      override_file_sorter = true,
+      case_mode = "smart_case",
+    },
+  },
 }
 
 return options

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -229,7 +229,7 @@ local default_plugins = {
 
   {
     "nvim-telescope/telescope.nvim",
-    dependencies = "nvim-treesitter/nvim-treesitter",
+    dependencies = { "nvim-treesitter/nvim-treesitter", { "nvim-telescope/telescope-fzf-native.nvim", build = "make" } },
     cmd = "Telescope",
     init = function()
       require("core.utils").load_mappings "telescope"


### PR DESCRIPTION
This is a suggestion that was already made in the Discord suggestion section. The addition of [telescope-fzf-native](https://github.com/nvim-telescope/telescope-fzf-native.nvim) can improve performance and sorting behavior (as also recommended by Telescope itself) so, it would be better to include this in **V3.0**.

_**Note**: this extension requires `make` and `gcc`_