### PR TITLE
Keep Visual Selection when indent

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -61,6 +61,8 @@ M.general = {
   v = {
     ["<Up>"] = { 'v:count || mode(1)[0:1] == "no" ? "k" : "gk"', "Move up", opts = { expr = true } },
     ["<Down>"] = { 'v:count || mode(1)[0:1] == "no" ? "j" : "gj"', "Move down", opts = { expr = true } },
+    ["<"] = { "<gv", "Indent line" },
+    [">"] = { ">gv", "Indent line" },
   },
 
   x = {


### PR DESCRIPTION
Features Added:
- When user indent visually selected text with `>>` or `<<` this change will keep visual selection

Reasoning:
Text indentation is used quite often. Many public vim configs contain similar mapping. My understanding is that this was not implemented earlier because `gv` was remapped until recent time.
