### PR TITLE
Add CTRL-w key to whichkey lazyloading

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -252,7 +252,7 @@ local default_plugins = {
   -- Only load whichkey after all the gui
   {
     "folke/which-key.nvim",
-    keys = { "<leader>", "<c-r>", '"', "'", "`", "c", "v", "g" },
+    keys = { "<leader>", "<c-r>", "<c-w>", '"', "'", "`", "c", "v", "g" },
     init = function()
       require("core.utils").load_mappings "whichkey"
     end,


### PR DESCRIPTION
CTRL+w has several window-related operations, but which key does not work by default, so I added it.

(I often check this because I don't remember all the keys.)