### PR TITLE
feat(mappings): make <esc> a cmd to remove flickering

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -16,7 +16,7 @@ M.general = {
   },
 
   n = {
-    ["<Esc>"] = { ":noh <CR>", "Clear highlights" },
+    ["<Esc>"] = { "<cmd> noh <CR>", "Clear highlights" },
     -- switch between windows
     ["<C-h>"] = { "<C-w>h", "Window left" },
     ["<C-l>"] = { "<C-w>l", "Window right" },


### PR DESCRIPTION
This is a small PR to address `Esc` flickering that will occur if you install `dressing.nvim` or any other plugin that will modify the appearance of command-line mode. Unless I missed something functionality is exactly the same.

If needed I can add screenshot, but this should be self-explanatory.

Edit - Screenshot is below:
<img width="1230" alt="flicker" src="https://github.com/NvChad/NvChad/assets/24460783/f1072de8-9ae2-42ea-b934-6515aafbc702">

