### PR TITLE
feat(cmp): Make words from opened buffers available in autocomplete snippet for faster coding.

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -105,9 +105,15 @@ local options = {
     }),
   },
   sources = {
+    { name = "buffer",
+      option = {
+        get_bufnrs = function()
+          return vim.api.nvim_list_bufs()
+        end
+      }
+    },
     { name = "nvim_lsp" },
     { name = "luasnip" },
-    { name = "buffer" },
     { name = "nvim_lua" },
     { name = "path" },
   },


### PR DESCRIPTION
I prefer working on open buffer and contents available in autocomplete in vim. This option will make the same feature available.

-Obie