### PR TITLE
remove Search, IncSearch and CurSearch highlights from cmp windows

### DIFF
--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -52,7 +52,7 @@ local options = {
   window = {
     completion = {
       side_padding = (cmp_style ~= "atom" and cmp_style ~= "atom_colored") and 1 or 0,
-      winhighlight = "Normal:CmpPmenu,CursorLine:CmpSel,Search:PmenuSel,Search:None,IncSearch:None,CurSearch:None",
+      winhighlight = "Normal:CmpPmenu,CursorLine:CmpSel,Search:None,IncSearch:None,CurSearch:None",
       scrollbar = false,
     },
     documentation = {

--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -52,12 +52,12 @@ local options = {
   window = {
     completion = {
       side_padding = (cmp_style ~= "atom" and cmp_style ~= "atom_colored") and 1 or 0,
-      winhighlight = "Normal:CmpPmenu,CursorLine:CmpSel,Search:PmenuSel",
+      winhighlight = "Normal:CmpPmenu,CursorLine:CmpSel,Search:PmenuSel,Search:None,IncSearch:None,CurSearch:None",
       scrollbar = false,
     },
     documentation = {
       border = border "CmpDocBorder",
-      winhighlight = "Normal:CmpDoc",
+      winhighlight = "Normal:CmpDoc,Search:None,IncSearch:None,CurSearch:None",
     },
   },
   snippet = {

--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -52,12 +52,12 @@ local options = {
   window = {
     completion = {
       side_padding = (cmp_style ~= "atom" and cmp_style ~= "atom_colored") and 1 or 0,
-      winhighlight = "Normal:CmpPmenu,CursorLine:CmpSel,Search:None,IncSearch:None,CurSearch:None",
+      winhighlight = "Normal:CmpPmenu,CursorLine:CmpSel,Search:None",
       scrollbar = false,
     },
     documentation = {
       border = border "CmpDocBorder",
-      winhighlight = "Normal:CmpDoc,Search:None,IncSearch:None,CurSearch:None",
+      winhighlight = "Normal:CmpDoc",
     },
   },
   snippet = {


### PR DESCRIPTION
In this commit, the search highlights have been removed from cmp windows to enhance the overall user experience.

Before changes:
![Screenshot_2023-11-12_10-32-31](https://github.com/NvChad/NvChad/assets/7275591/7373e869-6345-4256-abe7-bd6f04b6a23b)

After changes:
![Screenshot_2023-11-12_10-30-19](https://github.com/NvChad/NvChad/assets/7275591/2c89f16f-94fb-454c-b7e3-c6e92245ee2d)
