### PR TITLE
Consistent border style with Mason window

### DIFF
--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -4,6 +4,8 @@ local options = {
   PATH = "skip",
 
   ui = {
+    border = "rounded",
+
     icons = {
       package_pending = " ",
       package_installed = "󰄳 ",


### PR DESCRIPTION
Quick one—I really love the project, great stuff.

Just noticed an inconsistency that's been bothering me for a while, so I went ahead and fixed it. The border styles are all well and consistent, except when you pop open a Mason window—kind of breaks the flow.

So, my PR's all about making those Mason window borders round like the rest of the gang. Just a small tweak for a smoother look. Take a peek when you get a chance!