### PR TITLE
Add support for non-interactive bootstrapping

### DIFF
--- a/lua/core/bootstrap.lua
+++ b/lua/core/bootstrap.lua
@@ -1,5 +1,6 @@
 local M = {}
 local fn = vim.fn
+local env = vim.env
 
 M.echo = function(str)
   vim.cmd "redraw"
@@ -9,6 +10,18 @@ end
 local function shell_call(args)
   local output = fn.system(args)
   assert(vim.v.shell_error == 0, "External call failed with error code: " .. vim.v.shell_error .. "\n" .. output)
+end
+
+local function install_example_config_yn()
+  local input = ""
+  if env.NVCHAD_INSTALL_EXAMPLE_CONFIG ~= nil then
+    input = env.NVCHAD_INSTALL_EXAMPLE_CONFIG
+  else
+    input = fn.input "Do you want to install example custom config? (y/N): "
+  end
+  local lower_input = input:lower()
+  local is_yes = lower_input:sub(1,1) == "y"
+  return is_yes
 end
 
 M.lazy = function(install_path)
@@ -40,9 +53,7 @@ M.gen_chadrc_template = function()
   local path = fn.stdpath "config" .. "/lua/custom"
 
   if fn.isdirectory(path) ~= 1 then
-    local input = fn.input "Do you want to install example custom config? (y/N): "
-
-    if input:lower() == "y" then
+    if install_example_config_yn() then
       M.echo "Cloning example custom config repo..."
       shell_call { "git", "clone", "--depth", "1", "https://github.com/NvChad/example_config", path }
       fn.delete(path .. "/.git", "rf")

--- a/lua/core/bootstrap.lua
+++ b/lua/core/bootstrap.lua
@@ -1,6 +1,5 @@
 local M = {}
 local fn = vim.fn
-local env = vim.env
 
 M.echo = function(str)
   vim.cmd "redraw"
@@ -10,18 +9,6 @@ end
 local function shell_call(args)
   local output = fn.system(args)
   assert(vim.v.shell_error == 0, "External call failed with error code: " .. vim.v.shell_error .. "\n" .. output)
-end
-
-local function install_example_config_yn()
-  local input = ""
-  if env.NVCHAD_INSTALL_EXAMPLE_CONFIG ~= nil then
-    input = env.NVCHAD_INSTALL_EXAMPLE_CONFIG
-  else
-    input = fn.input "Do you want to install example custom config? (y/N): "
-  end
-  local lower_input = input:lower()
-  local is_yes = lower_input:sub(1,1) == "y"
-  return is_yes
 end
 
 M.lazy = function(install_path)
@@ -53,7 +40,9 @@ M.gen_chadrc_template = function()
   local path = fn.stdpath "config" .. "/lua/custom"
 
   if fn.isdirectory(path) ~= 1 then
-    if install_example_config_yn() then
+    local input = vim.env.NVCHAD_EXAMPLE_CONFIG or fn.input "Do you want to install example custom config? (y/N): "
+
+    if input:lower() == "y" then
       M.echo "Cloning example custom config repo..."
       shell_call { "git", "clone", "--depth", "1", "https://github.com/NvChad/example_config", path }
       fn.delete(path .. "/.git", "rf")


### PR DESCRIPTION
Currently, bootstrapping NvChad requires interactive input on the first run, which makes it impossible to use in Dockerfiles. This PR adds a way to answer the "Do you want to install example custom config?" prompt non-interactively via an environment variable.

To run bootstrapping non-interactively, set the `NVCHAD_INSTALL_EXAMPLE_CONFIG` environment variable to the answer you want, and then run nvim, e.g.:
```
NVCHAD_INSTALL_EXAMPLE_CONFIG=no nvim -c "autocmd User PackerComplete quitall" -c "quitall"
```
Which will automatically do all bootstrapping without installing the example config and then immediately exit.