### PR TITLE
[feat] Make gitsigns init function async

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -96,7 +96,7 @@ local default_plugins = {
       vim.api.nvim_create_autocmd({ "BufRead" }, {
         group = vim.api.nvim_create_augroup("GitSignsLazyLoad", { clear = true }),
         callback = function()
-          vim.fn.jobstart({"git", "-C", vim.fn.expand "%:p:h", "rev-parse"},
+          vim.fn.jobstart({"git", "-C", vim.loop.cwd(), "rev-parse"},
             {
               on_exit = function(_, return_code)
                 if return_code == 0 then

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -96,13 +96,18 @@ local default_plugins = {
       vim.api.nvim_create_autocmd({ "BufRead" }, {
         group = vim.api.nvim_create_augroup("GitSignsLazyLoad", { clear = true }),
         callback = function()
-          vim.fn.system("git -C " .. '"' .. vim.fn.expand "%:p:h" .. '"' .. " rev-parse")
-          if vim.v.shell_error == 0 then
-            vim.api.nvim_del_augroup_by_name "GitSignsLazyLoad"
-            vim.schedule(function()
-              require("lazy").load { plugins = { "gitsigns.nvim" } }
-            end)
-          end
+          vim.fn.jobstart({"git", "-C", vim.fn.expand "%:p:h", "rev-parse"},
+            {
+              on_exit = function(_, return_code)
+                if return_code == 0 then
+                  vim.api.nvim_del_augroup_by_name "GitSignsLazyLoad"
+                  vim.schedule(function()
+                    require("lazy").load { plugins = { "gitsigns.nvim" } }
+                  end)
+                end
+              end
+            }
+          )
         end,
       })
     end,


### PR DESCRIPTION
This function is running git and also initializing a shell, which can be a relatively slow operation. By leveraging the jobs api, we run the command in background, reducing the time it takes for the buffer to be available to the user.

Fixes NvChad/ui#215