### PR TITLE
Treesitter auto import

### DIFF
--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -1,5 +1,5 @@
 local options = {
-  ensure_installed = { "lua" },
+  auto_install = true,
 
   highlight = {
     enable = true,


### PR DESCRIPTION
Adding auto import to treesitter allows to have all required languages and not only lua. I was having issues reading help files because treesitter didn't have all the required tokens