### PR TITLE
fix: ensure install all neovim bundled parsers

### DIFF
--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -1,5 +1,5 @@
 local options = {
-  ensure_installed = { "lua" },
+  ensure_installed = { "lua", "c", "vimdoc", "bash", "python", "markdown", "markdown_inline" },
 
   highlight = {
     enable = true,


### PR DESCRIPTION
There can be more cases in the future where the bundled parser is not compatible with nvim-treesitter's queries, let's just ensure install all the bundled parsers to avoid the issue.