### PR TITLE
Add Autosave for NvChad!

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -270,6 +270,11 @@ local default_plugins = {
       require("which-key").setup(opts)
     end,
   },
+  {
+    "Pocco81/auto-save.nvim",
+    enabled = true,
+    trigger_events = {"InsertLeave", "TextChanged"},
+  }
 }
 
 local config = require("core.utils").load_config()


### PR DESCRIPTION
This PR adds autosaving features through the [Pocco81's Autosave plugin](https://github.com/Pocco81/auto-save.nvim)

In other words, this PR should completely remove the need for the `:w` command, further enhancing NvChad.