### PR TITLE
fix: Deep copy of key mappings instead of in-place modification

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -16,7 +16,24 @@ M.load_config = function()
   return config
 end
 
-M.remove_disabled_keys = function(chadrc_mappings, default_mappings)
+-- Copied from http://lua-users.org/wiki/CopyTable
+M.deepcopy = function(orig)
+    local orig_type = type(orig)
+    local copy
+    if orig_type == 'table' then
+        copy = {}
+        for orig_key, orig_value in next, orig, nil do
+            copy[M.deepcopy(orig_key)] = M.deepcopy(orig_value)
+        end
+        setmetatable(copy, M.deepcopy(getmetatable(orig)))
+    else -- number, string, boolean, etc
+        copy = orig
+    end
+    return copy
+end
+
+M.remove_disabled_keys = function(chadrc_mappings, default_mappings_orig)
+  local default_mappings = M.deepcopy(default_mappings_orig)
   if not chadrc_mappings then
     return default_mappings
   end


### PR DESCRIPTION
In order to change default key mappings to the ones that I'm used to, I've tried to add something like this in my `custom/chadrc.lua`:

```lua
local default_mappings = require "core.mappings"

---@type ChadrcConfig
local M = {}

M.mappings = {
    disabled = {
        n = {
            ["<leader>ca"] = {},
        },
    },
    lspconfig = {
        n = {
            ["<leader>vca"] = default_mappings.lspconfig.n["<leader>ca"],
        },
    }
}
```

But because original mappings are modified in-place and (I suppose) because lua doesn't reload the `core.mappings` package but uses it's in-memory representation, I can't use the old mappings. If there is a proper way to remap the default key mappings, I'd be happy to know it. Thank you!