### PR TITLE
fix: mapping update for new version of indent-blankline plugin

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -391,25 +391,18 @@ M.blankline = {
   n = {
     ["<leader>cc"] = {
       function()
-        local config = {
-          scope = {
-            exclude = {
-              language = {},
-              node_type = {},
-            },
-            include = {
-              node_type = {},
-            },
-            injected_languages = true,
-          },
-        }
+        local config = { scope = {} }
+        config.scope.exclude = { language = {}, node_type = {} }
+        config.scope.include = { node_type = {} }
+
         local node = require("ibl.scope").get(vim.api.nvim_get_current_buf(), config)
 
         if node then
           local start_row, _, end_row, _ = node:range()
+
           if start_row ~= end_row then
             vim.api.nvim_win_set_cursor(vim.api.nvim_get_current_win(), { start_row + 1, 0 })
-            vim.cmd [[normal! _]]
+            vim.api.nvim_feedkeys("_", "n", true)
           end
         end
       end,

--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -391,14 +391,26 @@ M.blankline = {
   n = {
     ["<leader>cc"] = {
       function()
-        local ok, start = require("indent_blankline.utils").get_current_context(
-          vim.g.indent_blankline_context_patterns,
-          vim.g.indent_blankline_use_treesitter_scope
-        )
+        local config = {
+          scope = {
+            exclude = {
+              language = {},
+              node_type = {},
+            },
+            include = {
+              node_type = {},
+            },
+            injected_languages = true,
+          },
+        }
+        local node = require("ibl.scope").get(vim.api.nvim_get_current_buf(), config)
 
-        if ok then
-          vim.api.nvim_win_set_cursor(vim.api.nvim_get_current_win(), { start, 0 })
-          vim.cmd [[normal! _]]
+        if node then
+          local start_row, _, end_row, _ = node:range()
+          if start_row ~= end_row then
+            vim.api.nvim_win_set_cursor(vim.api.nvim_get_current_win(), { start_row + 1, 0 })
+            vim.cmd [[normal! _]]
+          end
         end
       end,
 


### PR DESCRIPTION
I really like this project and I am using the version 3.0 branch of nvchad.

While testing I found an error that continued to call an obsolete function called:

`require("indent_blankline.utils").get_current_context `

and therefore that it did not work for the new version of the indent-blankline library;

update the function replacing with :

`require("ibl.scope").get `

so there are no problems, I hope it is useful