### PR TITLE
fix: Better approach to check if the system is Windows when setting PATH

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -57,7 +57,7 @@ for _, provider in ipairs { "node", "perl", "python3", "ruby" } do
 end
 
 -- add binaries installed by mason.nvim to path
-local is_windows = vim.loop.os_uname().sysname == "Windows_NT"
+local is_windows = vim.fn.has("win32")
 vim.env.PATH = vim.fn.stdpath "data" .. "/mason/bin" .. (is_windows and ";" or ":") .. vim.env.PATH
 
 -------------------------------------- autocmds ------------------------------------------


### PR DESCRIPTION
Now the check for Windows no longer requires luv's function `os_uname()`, which might not have a unique return value when neovim is built using different toolchains (MSVC, MinGW, etc).

For example, the neovim version distributed in the `mingw-w64-ucrt-x86_64-neovim` package from MSYS2 reports itself as `MINGW32_NT-10.0` rather than `Windows_NT`, which causes PATH to not be set properly. This has been fixed.

*Edit: Closed as integers in conditionals don't behave as I expected. Will open another request shortly.