### PR TITLE
fix: Remove Telescope unsupported layout_config key `results_width`

### DIFF
--- a/lua/plugins/configs/telescope.lua
+++ b/lua/plugins/configs/telescope.lua
@@ -21,7 +21,6 @@ local options = {
       horizontal = {
         prompt_position = "top",
         preview_width = 0.55,
-        results_width = 0.8,
       },
       vertical = {
         mirror = false,


### PR DESCRIPTION
The `results_width` option is causing errors at certain window or font sizes when a Telescope picker with the `horizontal` or `flex` strategy is loaded for the first time:

![Screenshot_20240226_035922](https://github.com/NvChad/NvChad/assets/24460484/d7ff365f-6726-49f1-b86c-871b9ac3c311)

Removing that option fix the problem. Also, from the Telescope [changelog](https://github.com/nvim-telescope/telescope.nvim/blob/2e1e382df42467029b493c143c2e727028140214/doc/telescope_changelog.txt#L43C1-L46C54) the option was removed on May 17, 2021:



> {results_width}: This key actually never did anything. It was leftover from
> some hacking that I had attempted before. Instead you should be using
> something like the `preview_width` configuration option for
> |layout_strategies.horizontal()|
> 
> You should get error messages when you try and use any of the above keys now.

