### PR TITLE
add vim.g.vscode_snippets_exclude option

### DIFF
--- a/lua/nvchad/configs/luasnip.lua
+++ b/lua/nvchad/configs/luasnip.lua
@@ -1,5 +1,5 @@
 -- vscode format
-require("luasnip.loaders.from_vscode").lazy_load()
+require("luasnip.loaders.from_vscode").lazy_load { exclude = vim.g.vscode_snippets_exclude or {} }
 require("luasnip.loaders.from_vscode").lazy_load { paths = "your path!" }
 require("luasnip.loaders.from_vscode").lazy_load { paths = vim.g.vscode_snippets_path or "" }
 


### PR DESCRIPTION
The `exclude` option for luasnip is useful for disabling snippets which a user may not want on by default.

For example the `all` option includes a snippet for `timeHMS` which always gets caught by `cmp` when typing `ts` for me which means all my typescript files end up as `file.16:07:21`