### PR TITLE
add more gitsigns mappings

### DIFF
--- a/lua/nvchad/configs/gitsigns.lua
+++ b/lua/nvchad/configs/gitsigns.lua
@@ -20,6 +20,28 @@ local options = {
     map("n", "<leader>rh", gs.reset_hunk, opts "Reset Hunk")
     map("n", "<leader>ph", gs.preview_hunk, opts "Preview Hunk")
     map("n", "<leader>gb", gs.blame_line, opts "Blame Line")
+    map("n", "<leader>td", gs.toggle_deleted, opts "Toggle deleted")
+    
+    map("n", "]c", function()
+      if vim.wo.diff then
+        return "]c"
+      end
+      vim.schedule(function()
+        require("gitsigns").next_hunk()
+      end)
+      return "<Ignore>"
+    end, { desc = "Jump to next hunk", expr = true })
+    
+    map("n", "[c", function()
+      if vim.wo.diff then
+        return "[c"
+      end
+      vim.schedule(function()
+        require("gitsigns").prev_hunk()
+      end)
+      return "<Ignore>"
+    end, { desc = "Jump to prev hunk", expr = true })
+    
   end,
 }
 


### PR DESCRIPTION
this adds `[c` ,`]c`, `<leader>td` mappings like in v2.0