### PR TITLE
Fix reload_module typo in autocmds

### DIFF
--- a/lua/nvchad/autocmds.lua
+++ b/lua/nvchad/autocmds.lua
@@ -21,7 +21,7 @@ autocmd("BufWritePost", {
     local module = string.gsub(fp, "^.*/" .. app_name .. "/lua/", ""):gsub("/", ".")
 
     require("plenary.reload").reload_module "nvconfig"
-    require("plenary.reload").relead_module "chadrc"
+    require("plenary.reload").reload_module "chadrc"
     require("plenary.reload").reload_module "base46"
     require("plenary.reload").reload_module(module)
 


### PR DESCRIPTION
Fixes the following error due to typo:

```
Error executing lua callback: attempt to call field 'relead_module' (a nil value)
```

