### PR TITLE
New option "ui.tabufline.show_tabs_always"

### DIFF
--- a/lua/nvconfig.lua
+++ b/lua/nvconfig.lua
@@ -31,6 +31,7 @@ M.ui = {
   -- lazyload it when there are 1+ buffers
   tabufline = {
     enabled = true,
+    show_tabs_always = false,
     lazyload = true,
     order = { "treeOffset", "buffers", "tabs", "btns" },
     modules = nil,


### PR DESCRIPTION
Draw the tabs even if there's only one buffer opened.