### PR TITLE
comments: use neovim native commenting

### DIFF
--- a/lua/nvchad/mappings.lua
+++ b/lua/nvchad/mappings.lua
@@ -44,15 +44,8 @@ map("n", "<leader>x", function()
 end, { desc = "buffer close" })
 
 -- Comment
-map("n", "<leader>/", function()
-  -- https://github.com/neovim/neovim/blob/efa45832ea02e777ce3f5556ef3cd959c164ec24/runtime/lua/vim/_defaults.lua#L142
-  return require("vim._comment").operator() .. "_"
-end, { desc = "comment toggle", expr = true })
-
-map("v", "<leader>/", function()
-  -- https://github.com/neovim/neovim/blob/efa45832ea02e777ce3f5556ef3cd959c164ec24/runtime/lua/vim/_defaults.lua#L137
-  return require("vim._comment").operator()
-end, { desc = "comment toggle", expr = true })
+map("n", "<leader>/", "gcc", { desc = "comment toggle", remap = true })
+map("v", "<leader>/", "gc", { desc = "comment toggle", remap = true })
 
 -- nvimtree
 map("n", "<C-n>", "<cmd>NvimTreeToggle<CR>", { desc = "nvimtree toggle window" })

--- a/lua/nvchad/mappings.lua
+++ b/lua/nvchad/mappings.lua
@@ -45,15 +45,14 @@ end, { desc = "buffer close" })
 
 -- Comment
 map("n", "<leader>/", function()
-  require("Comment.api").toggle.linewise.current()
-end, { desc = "comment toggle" })
+  -- https://github.com/neovim/neovim/blob/efa45832ea02e777ce3f5556ef3cd959c164ec24/runtime/lua/vim/_defaults.lua#L142
+  return require("vim._comment").operator() .. "_"
+end, { desc = "comment toggle", expr = true })
 
-map(
-  "v",
-  "<leader>/",
-  "<ESC><cmd>lua require('Comment.api').toggle.linewise(vim.fn.visualmode())<CR>",
-  { desc = "comment toggle" }
-)
+map("v", "<leader>/", function()
+  -- https://github.com/neovim/neovim/blob/efa45832ea02e777ce3f5556ef3cd959c164ec24/runtime/lua/vim/_defaults.lua#L137
+  return require("vim._comment").operator()
+end, { desc = "comment toggle", expr = true })
 
 -- nvimtree
 map("n", "<C-n>", "<cmd>NvimTreeToggle<CR>", { desc = "nvimtree toggle window" })

--- a/lua/nvchad/plugins/init.lua
+++ b/lua/nvchad/plugins/init.lua
@@ -123,21 +123,6 @@ return {
   },
 
   {
-    "numToStr/Comment.nvim",
-    keys = {
-      { "gcc", mode = "n", desc = "comment toggle current line" },
-      { "gc", mode = { "n", "o" }, desc = "comment toggle linewise" },
-      { "gc", mode = "x", desc = "comment toggle linewise (visual)" },
-      { "gbc", mode = "n", desc = "comment toggle current block" },
-      { "gb", mode = { "n", "o" }, desc = "comment toggle blockwise" },
-      { "gb", mode = "x", desc = "comment toggle blockwise (visual)" },
-    },
-    config = function(_, opts)
-      require("Comment").setup(opts)
-    end,
-  },
-
-  {
     "nvim-telescope/telescope.nvim",
     dependencies = { "nvim-treesitter/nvim-treesitter" },
     cmd = "Telescope",


### PR DESCRIPTION
I think nvchad can use neovim native commenting to keep the core clear & tiny.

User can choose other commenting plugin like `numToStr/Comment.nvim` or `folke/ts-comments.nvim` 