### PR TITLE
update (MasonInstallAll): install package only if it's missing

### DIFF
--- a/lua/nvchad/plugins/init.lua
+++ b/lua/nvchad/plugins/init.lua
@@ -55,9 +55,12 @@ return {
       require("mason").setup(opts)
 
       -- custom nvchad cmd to install all mason binaries listed
-      vim.api.nvim_create_user_command("MasonInstallAll", function()
+      vim.api.nvim_create_user_command('MasonInstallAll', function()
         if opts.ensure_installed and #opts.ensure_installed > 0 then
-          vim.cmd("MasonInstall " .. table.concat(opts.ensure_installed, " "))
+          for _, tool in ipairs(opts.ensure_installed) do
+            local p = require('mason-registry').get_package(tool)
+            if not p:is_installed() then p:install() end
+          end
         end
       end, {})
 


### PR DESCRIPTION
The ```MasonInstallAll``` command was installing all packages every time when run ```MasonInstallAll``` command. 

But we can make it like that so It will install only missing package not all. 

I think this is better approach. 

Anyway, Thanks for great work.