### PR TITLE
fix(MasonInstallAll):  mason registry refresh callback

### DIFF
--- a/lua/nvchad/plugins/init.lua
+++ b/lua/nvchad/plugins/init.lua
@@ -58,13 +58,16 @@ return {
       vim.api.nvim_create_user_command("MasonInstallAll", function()
         if opts.ensure_installed and #opts.ensure_installed > 0 then
           vim.cmd "Mason"
+          local mr = require("mason-registry")
 
-          for _, tool in ipairs(opts.ensure_installed) do
-            local p = require("mason-registry").get_package(tool)
-            if not p:is_installed() then
-              p:install()
+          mr.refresh(function()
+            for _, tool in ipairs(opts.ensure_installed) do
+              local p = mr.get_package(tool)
+              if not p:is_installed() then
+                p:install()
+              end
             end
-          end
+          end)
         end
       end, {})
 


### PR DESCRIPTION
Added refresh callback to make sure install package on first command. Right now it's not installing on first command.