### PR TITLE
fix: consistent slashes in path to Mason's bin directory (on Windows)

### DIFF
--- a/lua/nvchad/options.lua
+++ b/lua/nvchad/options.lua
@@ -56,4 +56,6 @@ g["loaded_ruby_provider"] = 0
 
 -- add binaries installed by mason.nvim to path
 local is_windows = vim.fn.has("win32") ~= 0
-vim.env.PATH = vim.fn.stdpath "data" .. "/mason/bin" .. (is_windows and ";" or ":") .. vim.env.PATH
+local sep = is_windows and "\\" or "/"
+local delim = is_windows and ";" or ":"
+vim.env.PATH = table.concat({vim.fn.stdpath "data", "mason", "bin"}, sep) .. delim .. vim.env.PATH


### PR DESCRIPTION
This is a slight correction to Mason's bin path that NvChad prepends to the vim.env.PATH on Windows.

Windows: now consistently uses backslashes instead of a mix of '\\' and'/'.
Linux/Mac, everything else: stays unaffected.

Before:
<img width="480" alt="before" src="https://github.com/NvChad/NvChad/assets/3280084/0291ad55-80ae-4b33-94f7-7bcb27930251">

After:
<img width="480" alt="after" src="https://github.com/NvChad/NvChad/assets/3280084/e9d948fc-a17f-42b6-ae38-f4d12a40f6c9">
