### PR TITLE
Use a more consistent table element access style

### DIFF
--- a/lua/nvchad/options.lua
+++ b/lua/nvchad/options.lua
@@ -49,10 +49,10 @@ opt.whichwrap:append "<>[]hl"
 -- g.mapleader = " "
 
 -- disable some default providers
-g["loaded_node_provider"] = 0
-g["loaded_python3_provider"] = 0
-g["loaded_perl_provider"] = 0
-g["loaded_ruby_provider"] = 0
+g.loaded_node_provider = 0
+g.loaded_python3_provider = 0
+g.loaded_perl_provider = 0
+g.loaded_ruby_provider = 0
 
 -- add binaries installed by mason.nvim to path
 local is_windows = vim.fn.has "win32" ~= 0


### PR DESCRIPTION
Since all the other options use the dot syntax to set them, I thought it would make this file more consistent and more maintainable with type hints