### PR TITLE
Prevent nvim-colorizer to attach to Lazy window

### DIFF
--- a/lua/nvchad/plugins/init.lua
+++ b/lua/nvchad/plugins/init.lua
@@ -189,7 +189,13 @@ return {
   {
     "NvChad/nvim-colorizer.lua",
     event = "User FilePost",
-    opts = { user_default_options = { names = false } },
+    opts = {
+      user_default_options = { names = false }
+      filetypes = {
+        "*",
+        "!lazy",
+      },
+    },
     config = function(_, opts)
       require("colorizer").setup(opts)
 


### PR DESCRIPTION
```lua
      filetypes = {
        "*", -- This is already the default value
        "!lazy", -- If we add this, we prevent the colorizer to attach to the Lazy window, which would colorize commits hash
      },
```