### PR TITLE
chore: prefer luasnip api methods over vim.fn.feedkeys in cmp's spec

### DIFF
--- a/lua/nvchad/configs/cmp.lua
+++ b/lua/nvchad/configs/cmp.lua
@@ -85,7 +85,7 @@ local options = {
       if cmp.visible() then
         cmp.select_next_item()
       elseif require("luasnip").expand_or_jumpable() then
-        vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-expand-or-jump", true, true, true), "")
+        require("luasnip").expand_or_jump()
       else
         fallback()
       end
@@ -95,7 +95,7 @@ local options = {
       if cmp.visible() then
         cmp.select_prev_item()
       elseif require("luasnip").jumpable(-1) then
-        vim.fn.feedkeys(vim.api.nvim_replace_termcodes("<Plug>luasnip-jump-prev", true, true, true), "")
+        require("luasnip").jump(-1)
       else
         fallback()
       end


### PR DESCRIPTION
This PR prefers luasnip's api methods for jumpables over `vim.fn.feedkeys` in cmp's spec