### PR TITLE
performance: defer clipboard because xsel and pbcopy can be slow

### DIFF
--- a/lua/nvchad/options.lua
+++ b/lua/nvchad/options.lua
@@ -1,3 +1,16 @@
+local group = vim.api.nvim_create_augroup("NvLazyClipboard", { clear = true })
+vim.api.nvim_create_autocmd("User", {
+  group = group,
+  pattern = "LazyDone",
+  callback = function()
+    local lazy_clipboard = vim.opt.clipboard -- could be changed by the user
+    vim.opt.clipboard = ""
+    vim.schedule(function() -- defer setting clipboard
+      vim.opt.clipboard = lazy_clipboard
+    end)
+  end,
+})
+
 local opt = vim.opt
 local o = vim.o
 local g = vim.g

--- a/lua/nvchad/plugins/init.lua
+++ b/lua/nvchad/plugins/init.lua
@@ -1,6 +1,26 @@
 return {
 
   {
+    "NvChad/NvChad",
+    init = function()
+      local spec = require("lazy.core.config").spec.plugins["NvChad"]
+      if not spec.config then
+        return
+      end
+
+      local config_function = spec.config -- NvChad/starter: requires options.lua
+      spec.config = function(...)
+        config_function(...)
+        local lazy_clipboard = vim.opt.clipboard -- defer setting clipboard
+        vim.opt.clipboard = ""
+        vim.schedule(function()
+          vim.opt.clipboard = lazy_clipboard
+        end)
+      end
+    end,
+  },
+
+  {
     "NvChad/base46",
     branch = "v2.5",
     build = function()

--- a/lua/nvchad/plugins/init.lua
+++ b/lua/nvchad/plugins/init.lua
@@ -1,26 +1,6 @@
 return {
 
   {
-    "NvChad/NvChad",
-    init = function()
-      local spec = require("lazy.core.config").spec.plugins["NvChad"]
-      if not spec.config then
-        return
-      end
-
-      local config_function = spec.config -- NvChad/starter: requires options.lua
-      spec.config = function(...)
-        config_function(...)
-        local lazy_clipboard = vim.opt.clipboard -- defer setting clipboard
-        vim.opt.clipboard = ""
-        vim.schedule(function()
-          vim.opt.clipboard = lazy_clipboard
-        end)
-      end
-    end,
-  },
-
-  {
     "NvChad/base46",
     branch = "v2.5",
     build = function()


### PR DESCRIPTION
See [this](https://github.com/LazyVim/LazyVim/discussions/4112) discussion in LazyVim

The approach discussed has been merged in [LazyVim](https://github.com/LazyVim/LazyVim/pull/4120) and [AstroNvim](https://github.com/AstroNvim/astrocore/pull/28)

TLDR: 
Startup time performance is affected quite significantly when the clipboard provider is `xsel`(linux) or `pbcopy`(macos). I expect an improvement in these cases, especially on older pc's.

This PR makes sure that `vim.opt.clipboard` is only applied after `UiEnter`

@siduck, in case you are interested, please let me know if the code needs adjustments.
I "decorated" the config function defined in `Nvchad/starter".