### PR TITLE
Update terminal mapping description

### DIFF
--- a/lua/nvchad/mappings.lua
+++ b/lua/nvchad/mappings.lua
@@ -84,7 +84,7 @@ end, { desc = "terminal new horizontal term" })
 
 map("n", "<leader>v", function()
   require("nvchad.term").new { pos = "vsp" }
-end, { desc = "terminal new vertical window" })
+end, { desc = "terminal new vertical term" })
 
 -- toggleable
 map({ "n", "t" }, "<A-v>", function()


### PR DESCRIPTION
Hello,

I noticed a small inconsistency in the terminal mapping descriptions. The mapping that creates a new terminal window was labeled 'New vertical window,' while similar mappings were labeled ' *** term'.

This commit updates the terminal mapping description, replacing 'window' with 'term.' It better reflects the purpose of the mapping and aligns with other similar mappings

**Before**
![image](https://github.com/user-attachments/assets/b513be23-f11e-4383-82f8-ec67613a76ad)

**After**
![image](https://github.com/user-attachments/assets/e4d8dd02-b5b0-46c9-8946-fd18dccfd9d8)

Thank you
