### PR TITLE
Add resume previous search with telescope

### DIFF
--- a/lua/nvchad/mappings.lua
+++ b/lua/nvchad/mappings.lua
@@ -61,6 +61,7 @@ map("n", "<leader>fz", "<cmd>Telescope current_buffer_fuzzy_find<CR>", { desc = 
 map("n", "<leader>cm", "<cmd>Telescope git_commits<CR>", { desc = "telescope git commits" })
 map("n", "<leader>gt", "<cmd>Telescope git_status<CR>", { desc = "telescope git status" })
 map("n", "<leader>pt", "<cmd>Telescope terms<CR>", { desc = "telescope pick hidden term" })
+map("n", "<leader>f<CR>", "<cmd>Telescope resume<cr>", { desc = "telescope resume previous search" })
 
 map("n", "<leader>th", function()
   require("nvchad.themes").open()


### PR DESCRIPTION
Continue the previous search with telescope from where we left it.

I know users can add it themselves, but this is a great feature that should come with NvChad and doesn't conflict with other keybinds.