### PR TITLE
fix(telescope): lazy load extensions in defined list

### DIFF
--- a/lua/nvchad/configs/telescope.lua
+++ b/lua/nvchad/configs/telescope.lua
@@ -19,6 +19,6 @@ return {
     },
   },
 
-  extensions_list = { "themes", "terms" },
+  extensions_list = {},
   extensions = {},
 }

--- a/lua/nvchad/plugins/init.lua
+++ b/lua/nvchad/plugins/init.lua
@@ -152,6 +152,14 @@ return {
     opts = function()
       return require "nvchad.configs.telescope"
     end,
+    config = function(_, opts)
+      local telescope = require "telescope"
+      telescope.setup(opts)
+      -- load extensions
+      for _, ext in ipairs(opts.extensions_list) do
+        telescope.load_extension(ext)
+      end
+    end,
   },
 
   {


### PR DESCRIPTION
Should we really need to remove auto load extensions function ? I'm using `file_browser` extensions, and I saw it failed to load my config after newest commit.

Up to now, we can remove `terms` and `themes`because they work independently.