### PR TITLE
perf: use cmp-async-path for async indexing without blocking main UI

### DIFF
--- a/lua/nvchad/configs/cmp.lua
+++ b/lua/nvchad/configs/cmp.lua
@@ -50,7 +50,7 @@ local options = {
     { name = "luasnip" },
     { name = "buffer" },
     { name = "nvim_lua" },
-    { name = "path" },
+    { name = "async_path" },
   },
 }
 

--- a/lua/nvchad/plugins/init.lua
+++ b/lua/nvchad/plugins/init.lua
@@ -137,8 +137,8 @@ return {
         "hrsh7th/cmp-nvim-lua",
         "hrsh7th/cmp-nvim-lsp",
         "hrsh7th/cmp-buffer",
-        "hrsh7th/cmp-path",
-      },
+        "https://codeberg.org/FelipeLema/cmp-async-path.git"
+      }
     },
     opts = function()
       return require "nvchad.configs.cmp"


### PR DESCRIPTION
Current `cmp-path` blocks main UI while indexing, especially when scanning directories with a large number of files. This behavior stutters UI and makes coding experience totally unpleasant (mainly on low I/O disks).