### PR TITLE
lspconfig: more visually appealing diagnostics display

### DIFF
--- a/lua/nvchad/configs/diagnostics.lua
+++ b/lua/nvchad/configs/diagnostics.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+M.setup = function()
+  vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
+    virtual_text = false, -- no inline diagnostics
+    underline = true, -- underline problematic code
+  })
+
+  -- Set the update time for diagnostics
+  vim.o.updatetime = 250
+
+  -- Automatically show diagnostics on cursor hold
+  vim.cmd [[
+    autocmd CursorHold,CursorHoldI * lua vim.diagnostic.open_float(nil, { focus = false })
+  ]]
+end
+
+return M

--- a/lua/nvchad/configs/lspconfig.lua
+++ b/lua/nvchad/configs/lspconfig.lua
@@ -7,6 +7,9 @@ M.on_attach = function(_, bufnr)
     return { buffer = bufnr, desc = "LSP " .. desc }
   end
 
+  local diagnostics = require "configs.diagnostics"
+  diagnostics.setup()
+
   map("n", "gD", vim.lsp.buf.declaration, opts "Go to declaration")
   map("n", "gd", vim.lsp.buf.definition, opts "Go to definition")
   map("n", "gi", vim.lsp.buf.implementation, opts "Go to implementation")


### PR DESCRIPTION
- Change diagnostics display from inline virutal text to a bordered window that displays upon holding cursor over the offending line
- Provides wrapping of diagnostics messages on smaller buffers
- Underline the offending code line

Examples:
<img width="812" alt="Screenshot 2024-11-06 at 10 32 09 AM" src="https://github.com/user-attachments/assets/a1f9dea6-2089-46aa-95db-5675cc0ae27d">

<img width="1275" alt="Screenshot 2024-11-06 at 10 33 11 AM" src="https://github.com/user-attachments/assets/86796ea4-c897-4aac-8965-366e96a32851">
