### PR TITLE
feat(mappings): add Ctrl + Backspace support to delete a word in insert mode

### DIFF
--- a/lua/nvchad/mappings.lua
+++ b/lua/nvchad/mappings.lua
@@ -17,6 +17,9 @@ map("n", "<Esc>", "<cmd>noh<CR>", { desc = "general clear highlights" })
 map("n", "<C-s>", "<cmd>w<CR>", { desc = "general save file" })
 map("n", "<C-c>", "<cmd>%y+<CR>", { desc = "general copy whole file" })
 
+map("i", "<C-BS>", "<C-w>", { desc = "general delete the previous word in insert mode" })
+map("i", "<C-H>", "<C-w>", { desc = "general delete the previous word in insert mode" })
+
 map("n", "<leader>n", "<cmd>set nu!<CR>", { desc = "toggle line number" })
 map("n", "<leader>rn", "<cmd>set rnu!<CR>", { desc = "toggle relative number" })
 map("n", "<leader>ch", "<cmd>NvCheatsheet<CR>", { desc = "toggle nvcheatsheet" })


### PR DESCRIPTION
I've added a keymap to make Vim more accessible to newcomers by introducing support for deleting a word using `Ctrl + Backspace` in insert mode. This behavior is common in other editors and enhances the onboarding experience for users transitioning to Vim.

The keymap maps `<C-BS>` to Vim's built-in `<C-w>` command, which is already familiar to experienced Vim/Neovim users for deleting the previous word. 

Even if this functionality already exists, I believe someone will find it helpful ;)

Both `<C-BS>` and `<C-H>` are included to ensure compatibility, as key interpretation can vary across terminals, but either keymap can be removed accordingly based on the terminal's behavior.
```lua
map("i", "<C-BS>", "<C-w>", { desc = "general delete the previous word in insert mode" })
map("i", "<C-H>", "<C-w>", { desc = "general delete the previous word in insert mode" })
```

### More on key interpretation

We can check our terminal's interpretation by running `cat -v` in our terminal and pressing `Ctrl + Backspace`. 
> For example, If we see `^H` (`^` represents `Ctrl`), our terminal supports `<C-H>` version. In this case, we can remove the `<C-BS>` keymap.
