### PR TITLE
Add auto_install to Treesitter to automatically install missing parsers

### DIFF
--- a/lua/nvchad/configs/treesitter.lua
+++ b/lua/nvchad/configs/treesitter.lua
@@ -6,6 +6,8 @@ end)
 return {
   ensure_installed = { "lua", "luadoc", "printf", "vim", "vimdoc" },
 
+  auto_install = true,
+  
   highlight = {
     enable = true,
     use_languagetree = true,


### PR DESCRIPTION
Just thought it might be a great idea to add this functionality, I can't see any downsides and think many might benefit.

Correct me if I'm wrong though.

https://github.com/nvim-treesitter/nvim-treesitter/blob/7e3942ceca9e0c28760f77ac33bc16399146d879/doc/nvim-treesitter.txt#L55