### PR TITLE
fix(lspconfig): use more stable 0.11 compatibility check

### DIFF
--- a/lua/nvchad/configs/lspconfig.lua
+++ b/lua/nvchad/configs/lspconfig.lua
@@ -72,7 +72,7 @@ M.defaults = function()
 
   -- Support 0.10 temporarily
 
-  if vim.version().minor == 11 then
+  if vim.lsp.config then
     vim.lsp.config("*", { capabilities = M.capabilities, on_init = M.on_init })
     vim.lsp.config("lua_ls", { settings = lua_lsp_settings })
     vim.lsp.enable "lua_ls"


### PR DESCRIPTION
Previously only the minor version has been checked for equality, which means it is brittle whenever we reach 0.12. Independently of when this is expected to be removed, it's simply much safer to check if the expected functionality is available by testing `vim.lsp.enable` for nil.

Fixes 84f8170fdab2a9bb82f36fe76c68bca2241c50d8