### PR TITLE
fix: disable lazy-loading for gitsigns.nvim to fix errors on file open

### DIFF
--- a/lua/nvchad/plugins/init.lua
+++ b/lua/nvchad/plugins/init.lua
@@ -76,7 +76,7 @@ return {
   -- git stuff
   {
     "lewis6991/gitsigns.nvim",
-    event = "User FilePost",
+    lazy = false,
     opts = function()
       return require "nvchad.configs.gitsigns"
     end,


### PR DESCRIPTION
I am getting the same error as the one described in this ticket:
https://github.com/lewis6991/gitsigns.nvim/issues/1289

According to the plugin author, lazy-loading should not be used with this plugin as it performs its own lazy-loading.
Attempting to use lazy-loading, as done in the NvChad configuration leads to the error described:
https://github.com/lewis6991/gitsigns.nvim/issues/1289#issuecomment-2840371229