### PR TITLE
Set `lua_ls` runtime version to LuaJIT

### DIFF
--- a/lua/nvchad/configs/lspconfig.lua
+++ b/lua/nvchad/configs/lspconfig.lua
@@ -59,9 +59,7 @@ M.defaults = function()
 
   local lua_lsp_settings = {
     Lua = {
-      runtime = {
-        version = "LuaJIT",
-      },
+      runtime = { version = "LuaJIT" },
       workspace = {
         library = {
           vim.fn.expand "$VIMRUNTIME/lua",

--- a/lua/nvchad/configs/lspconfig.lua
+++ b/lua/nvchad/configs/lspconfig.lua
@@ -59,6 +59,9 @@ M.defaults = function()
 
   local lua_lsp_settings = {
     Lua = {
+      runtime = {
+        version = "LuaJIT",
+      },
       workspace = {
         library = {
           vim.fn.expand "$VIMRUNTIME/lua",


### PR DESCRIPTION
neovim lua runtime is `LuaJIT` , so we should set the default runtime of `lua_ls` to `LuaJIT` as well.

Ref: https://luals.github.io/wiki/settings/#runtimeversion