### PR TITLE
Migrate to nvim-treesitter 'main'

### DIFF
--- a/lua/nvchad/autocmds.lua
+++ b/lua/nvchad/autocmds.lua
@@ -26,11 +26,17 @@ autocmd({ "UIEnter", "BufReadPost", "BufNewFile" }, {
   end,
 })
 
-autocmd("FileType", {
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "*",
   callback = function()
-    -- TODO: nvim 0.12 will make error = false the default so we can remove it
-    if vim.treesitter.get_parser(nil, nil, { error = false }) then
-      vim.treesitter.start()
-    end
+    pcall(vim.treesitter.start)
   end,
 })
+
+local create_cmd = vim.api.nvim_create_user_command
+
+create_cmd("TSInstallAll", function()
+  local spec = require("lazy.core.config").plugins["nvim-treesitter"]
+  local opts = type(spec.opts) == "table" and spec.opts or {}
+  require("nvim-treesitter").install(opts.ensure_installed)
+end, {})

--- a/lua/nvchad/autocmds.lua
+++ b/lua/nvchad/autocmds.lua
@@ -25,3 +25,12 @@ autocmd({ "UIEnter", "BufReadPost", "BufNewFile" }, {
     end
   end,
 })
+
+autocmd("FileType", {
+  callback = function()
+    -- TODO: nvim 0.12 will make error = false the default so we can remove it
+    if vim.treesitter.get_parser(nil, nil, { error = false }) then
+      vim.treesitter.start()
+    end
+  end,
+})

--- a/lua/nvchad/configs/treesitter.lua
+++ b/lua/nvchad/configs/treesitter.lua
@@ -5,11 +5,4 @@ end)
 
 return {
   ensure_installed = { "lua", "luadoc", "printf", "vim", "vimdoc" },
-
-  highlight = {
-    enable = true,
-    use_languagetree = true,
-  },
-
-  indent = { enable = true },
 }

--- a/lua/nvchad/options.lua
+++ b/lua/nvchad/options.lua
@@ -55,6 +55,3 @@ local is_windows = vim.fn.has "win32" ~= 0
 local sep = is_windows and "\\" or "/"
 local delim = is_windows and ";" or ":"
 vim.env.PATH = table.concat({ vim.fn.stdpath "data", "mason", "bin" }, sep) .. delim .. vim.env.PATH
-
--- treesitter indentation
-vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"

--- a/lua/nvchad/options.lua
+++ b/lua/nvchad/options.lua
@@ -55,3 +55,6 @@ local is_windows = vim.fn.has "win32" ~= 0
 local sep = is_windows and "\\" or "/"
 local delim = is_windows and ";" or ":"
 vim.env.PATH = table.concat({ vim.fn.stdpath "data", "mason", "bin" }, sep) .. delim .. vim.env.PATH
+
+-- treesitter indentation
+vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"

--- a/lua/nvchad/plugins/init.lua
+++ b/lua/nvchad/plugins/init.lua
@@ -137,7 +137,7 @@ return {
         "hrsh7th/cmp-nvim-lua",
         "hrsh7th/cmp-nvim-lsp",
         "hrsh7th/cmp-buffer",
-       "https://codeberg.org/FelipeLema/cmp-async-path.git",
+        "https://codeberg.org/FelipeLema/cmp-async-path.git",
       },
     },
     opts = function()
@@ -156,15 +156,31 @@ return {
 
   {
     "nvim-treesitter/nvim-treesitter",
-    branch = "master",
     event = { "BufReadPost", "BufNewFile" },
-    cmd = { "TSInstall", "TSBufEnable", "TSBufDisable", "TSModuleInfo" },
+    cmd = { "TSInstall", "TSInstallFromGrammar", "TSUninstall", "TSLog" },
     build = ":TSUpdate",
+    branch = "main",
     opts = function()
       return require "nvchad.configs.treesitter"
     end,
     config = function(_, opts)
-      require("nvim-treesitter.configs").setup(opts)
+      -- ensure_installed is no longer part of nvim-treesitter, so we must extract it manually.
+      local ensure_installed = opts.ensure_installed
+      opts.ensure_installed = nil
+
+      local nvim_treesitter = require "nvim-treesitter"
+      nvim_treesitter.setup(opts)
+      nvim_treesitter.install(ensure_installed):await(function(err)
+        if err then
+          vim.notify("Failed to install TreeSitter parsers: " .. err, vim.log.levels.WARN)
+          return
+        end
+        -- start treesitter for all possible buffers
+        -- not all buffers will be possible, so we will pcall this for best effort.
+        for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+          pcall(vim.treesitter.start, buf)
+        end
+      end)
     end,
   },
 }

--- a/lua/nvchad/plugins/init.lua
+++ b/lua/nvchad/plugins/init.lua
@@ -137,7 +137,7 @@ return {
         "hrsh7th/cmp-nvim-lua",
         "hrsh7th/cmp-nvim-lsp",
         "hrsh7th/cmp-buffer",
-        "https://codeberg.org/FelipeLema/cmp-async-path.git",
+       "https://codeberg.org/FelipeLema/cmp-async-path.git",
       },
     },
     opts = function()
@@ -157,30 +157,10 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     event = { "BufReadPost", "BufNewFile" },
-    cmd = { "TSInstall", "TSInstallFromGrammar", "TSUninstall", "TSLog" },
-    build = ":TSUpdate",
-    branch = "main",
+    cmd = { "TSInstall", "TSBufEnable", "TSBufDisable", "TSModuleInfo" },
+    build = ":TSUpdate | TSInstallAll",
     opts = function()
       return require "nvchad.configs.treesitter"
-    end,
-    config = function(_, opts)
-      -- ensure_installed is no longer part of nvim-treesitter, so we must extract it manually.
-      local ensure_installed = opts.ensure_installed
-      opts.ensure_installed = nil
-
-      local nvim_treesitter = require "nvim-treesitter"
-      nvim_treesitter.setup(opts)
-      nvim_treesitter.install(ensure_installed):await(function(err)
-        if err then
-          vim.notify("Failed to install TreeSitter parsers: " .. err, vim.log.levels.WARN)
-          return
-        end
-        -- start treesitter for all possible buffers
-        -- not all buffers will be possible, so we will pcall this for best effort.
-        for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-          pcall(vim.treesitter.start, buf)
-        end
-      end)
     end,
   },
 }


### PR DESCRIPTION
This is my best stab at moving the nvim-treesitter integration to use the 'main' branch. I can personally say I haven't found any problems yet, but that doesn't mean there aren't any!

Grammars are still installed with the users' existing `ensure_installed` config entry.  I thought about having this be something in `chadrc`, but that seems to be primarily used by the `ui` plugin, not by the main plugin, and this helps maintain some level of backwards compatibility.

I have a couple questions for you
1) Is this an upgrade you're willing to pursue at this time?
2) If so, how would you like to roll it out? Do you want to handle it similar to the blink transition?  Do you want to make a breaking release to the library?

The big thing I wasn't able to cover in this transition is any migrations involving plugins that use `nvim-treesitter`; the new version doesn't manage them anymore  (From [the maintainer](https://github.com/nvim-treesitter/nvim-treesitter/discussions/7901#discussioncomment-13318323): 

> External plugins are not supported; they need to handle their own setup (as they should). Open an issue (but check first for existing issues or PRs!) at the plugin.

)