### PR TITLE
lspconfig.lua - client.supports_method is deprecated

### DIFF
--- a/lua/nvchad/configs/lspconfig.lua
+++ b/lua/nvchad/configs/lspconfig.lua
@@ -22,7 +22,7 @@ end
 
 -- disable semanticTokens
 M.on_init = function(client, _)
-  if client.supports_method "textDocument/semanticTokens" then
+  if client:supports_method "textDocument/semanticTokens" then
     client.server_capabilities.semanticTokensProvider = nil
   end
 end


### PR DESCRIPTION
client.supports_method is deprecated. Feature will be removed in Nvim 0.13. Switched to client:supports_method instead.