### PR TITLE
fix(lsp): backwards compatible client.supports_method

### DIFF
--- a/lua/nvchad/configs/lspconfig.lua
+++ b/lua/nvchad/configs/lspconfig.lua
@@ -22,8 +22,14 @@ end
 
 -- disable semanticTokens
 M.on_init = function(client, _)
-  if client.supports_method "textDocument/semanticTokens" then
-    client.server_capabilities.semanticTokensProvider = nil
+  if vim.fn.has "nvim-0.11" ~= 1 then
+    if client.supports_method "textDocument/semanticTokens" then
+      client.server_capabilities.semanticTokensProvider = nil
+    end
+  else
+    if client:supports_method "textDocument/semanticTokens" then
+      client.server_capabilities.semanticTokensProvider = nil
+    end
   end
 end
 


### PR DESCRIPTION
```
==============================================================================
vim.deprecated:                                                           

WARNING client.supports_method is deprecated. Feature will be removed in Nvim 0.13
  - ADVICE:
    - use client:supports_method instead.
    - stack traceback:
        /home/stapl/.local/share/nvim/lazy/NvChad/lua/nvchad/configs/lspconfig.lua:25
        /home/stapl/.local/share/nvim/lazy/nvim-lspconfig/lua/lspconfig/util.lua:324
        [C]:-1
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:491
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:578
        vim/_editor.lua:0

```
```lua
client:supports_method "textDocument/semanticTokens" then
```