### PR TITLE
Fix  migrate lua ls configuration from deprecated lspconfig.setup api

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -88,8 +88,7 @@ A fuzzy file finder, picker, sorter, previewer and much more:
 
 - Many beautiful themes, theme toggler by our [base46 plugin](https://github.com/NvChad/base46)
 - Inbuilt terminal toggling & management with [Nvterm](https://github.com/NvChad/nvterm)
-- NvChad updater, hide & unhide terminal buffers with [NvChad extensions](https://github.com/NvChad/extensions)
-- Lightweight & performant ui plugin with [NvChad UI](https://github.com/NvChad/ui) It provides statusline modules, tabufline ( tabs + buffer manager) , beautiful cheatsheets and much more!
+- Lightweight & performant ui plugin with [NvChad UI](https://github.com/NvChad/ui) It provides statusline modules, tabufline ( tabs + buffer manager) , beautiful cheatsheets, NvChad updater, hide & unhide terminal buffers, theme switcher and much more!
 - File navigation with [nvim-tree.lua](https://github.com/kyazdani42/nvim-tree.lua)
 - Beautiful and configurable icons with [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons)
 - Git diffs and more with [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim) 

--- a/.github/README.md
+++ b/.github/README.md
@@ -112,7 +112,7 @@ A fuzzy file finder, picker, sorter, previewer and much more:
 If you like NvChad and would like to support & appreciate it via donation then I'll gladly accept it. 
 
 [![kofi](https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/siduck)
-[![paypal](https://img.shields.io/badge/PayPal-00457C?style=for-the-badge&logo=paypal&logoColor=white)](https://paypal.me/siduck76)
+[![paypal](https://img.shields.io/badge/PayPal-00457C?style=for-the-badge&logo=paypal&logoColor=white)](https://paypal.me/siduck13)
 [![buymeacoffee](https://img.shields.io/badge/Buy_Me_A_Coffee-FFDD00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)](https://www.buymeacoffee.com/siduck)
 [![patreon](https://img.shields.io/badge/Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/siduck)
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coc-settings.json
 .luarc.json
 lazy-lock.json
 after
+**/.DS_Store

--- a/lua/core/bootstrap.lua
+++ b/lua/core/bootstrap.lua
@@ -40,21 +40,13 @@ M.gen_chadrc_template = function()
   local path = fn.stdpath "config" .. "/lua/custom"
 
   if fn.isdirectory(path) ~= 1 then
-    local input = vim.env.NVCHAD_EXAMPLE_CONFIG or fn.input "Do you want to install example custom config? (y/N): "
+    -- use very minimal chadrc
+    fn.mkdir(path, "p")
 
-    if input:lower() == "y" then
-      M.echo "Cloning example custom config repo..."
-      shell_call { "git", "clone", "--depth", "1", "https://github.com/NvChad/example_config", path }
-      fn.delete(path .. "/.git", "rf")
-    else
-      -- use very minimal chadrc
-      fn.mkdir(path, "p")
-
-      local file = io.open(path .. "/chadrc.lua", "w")
-      if file then
-        file:write "---@type ChadrcConfig\nlocal M = {}\n\nM.ui = { theme = 'onedark' }\n\nreturn M"
-        file:close()
-      end
+    local file = io.open(path .. "/chadrc.lua", "w")
+    if file then
+      file:write "---@type ChadrcConfig\nlocal M = {}\n\nM.ui = { theme = 'onedark' }\n\nreturn M"
+      file:close()
     end
   end
 end

--- a/lua/core/bootstrap.lua
+++ b/lua/core/bootstrap.lua
@@ -32,7 +32,7 @@ M.lazy = function(install_path)
   -- install plugins
   require "plugins"
 
-  -- mason packages & show post_boostrap screen
+  -- mason packages & show post_bootstrap screen
   require "nvchad.post_install"()
 end
 

--- a/lua/core/bootstrap.lua
+++ b/lua/core/bootstrap.lua
@@ -40,7 +40,7 @@ M.gen_chadrc_template = function()
   local path = fn.stdpath "config" .. "/lua/custom"
 
   if fn.isdirectory(path) ~= 1 then
-    local input = fn.input "Do you want to install example custom config? (y/N): "
+    local input = vim.env.NVCHAD_EXAMPLE_CONFIG or fn.input "Do you want to install example custom config? (y/N): "
 
     if input:lower() == "y" then
       M.echo "Cloning example custom config repo..."

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -107,6 +107,29 @@ autocmd("BufWritePost", {
   end,
 })
 
+-- user event that loads after UIEnter + only if file buf is there
+vim.api.nvim_create_autocmd({ "UIEnter", "BufReadPost", "BufNewFile" }, {
+  group = vim.api.nvim_create_augroup("NvFilePost", { clear = true }),
+  callback = function(args)
+    local file = vim.api.nvim_buf_get_name(args.buf)
+    local buftype = vim.api.nvim_buf_get_option(args.buf, "buftype")
+
+    if not vim.g.ui_entered and args.event == "UIEnter" then
+      vim.g.ui_entered = true
+    end
+
+    if file ~= "" and buftype ~= "nofile" and vim.g.ui_entered then
+      vim.api.nvim_exec_autocmds("User", { pattern = "FilePost", modeline = false })
+      vim.api.nvim_del_augroup_by_name "NvFilePost"
+
+      vim.schedule(function()
+        vim.api.nvim_exec_autocmds("FileType", {})
+        require("editorconfig").config(args.buf)
+      end, 0)
+    end
+  end,
+})
+
 -------------------------------------- commands ------------------------------------------
 local new_cmd = vim.api.nvim_create_user_command
 

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -57,7 +57,7 @@ for _, provider in ipairs { "node", "perl", "python3", "ruby" } do
 end
 
 -- add binaries installed by mason.nvim to path
-local is_windows = vim.loop.os_uname().sysname == "Windows_NT"
+local is_windows = vim.fn.has("win32") ~= 0
 vim.env.PATH = vim.fn.stdpath "data" .. "/mason/bin" .. (is_windows and ";" or ":") .. vim.env.PATH
 
 -------------------------------------- autocmds ------------------------------------------

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -124,7 +124,10 @@ vim.api.nvim_create_autocmd({ "UIEnter", "BufReadPost", "BufNewFile" }, {
 
       vim.schedule(function()
         vim.api.nvim_exec_autocmds("FileType", {})
-        require("editorconfig").config(args.buf)
+
+        if vim.g.editorconfig then
+          require("editorconfig").config(args.buf)
+        end
       end, 0)
     end
   end,

--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -16,7 +16,7 @@ M.general = {
   },
 
   n = {
-    ["<Esc>"] = { ":noh <CR>", "Clear highlights" },
+    ["<Esc>"] = { "<cmd> noh <CR>", "Clear highlights" },
     -- switch between windows
     ["<C-h>"] = { "<C-w>h", "Window left" },
     ["<C-l>"] = { "<C-w>l", "Window right" },

--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -193,7 +193,7 @@ M.lspconfig = {
       "LSP references",
     },
 
-    ["<leader>f"] = {
+    ["<leader>lf"] = {
       function()
         vim.diagnostic.open_float { border = "rounded" }
       end,

--- a/lua/plugins/configs/cmp.lua
+++ b/lua/plugins/configs/cmp.lua
@@ -52,7 +52,7 @@ local options = {
   window = {
     completion = {
       side_padding = (cmp_style ~= "atom" and cmp_style ~= "atom_colored") and 1 or 0,
-      winhighlight = "Normal:CmpPmenu,CursorLine:CmpSel,Search:PmenuSel",
+      winhighlight = "Normal:CmpPmenu,CursorLine:CmpSel,Search:None",
       scrollbar = false,
     },
     documentation = {

--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -5,14 +5,16 @@ local M = {}
 local utils = require "core.utils"
 
 -- export on_attach & capabilities for custom lspconfigs
-
 M.on_attach = function(client, bufnr)
   utils.load_mappings("lspconfig", { buffer = bufnr })
 
   if client.server_capabilities.signatureHelpProvider then
     require("nvchad.signature").setup(client)
   end
+end
 
+-- disable semantic tokens
+M.on_init = function(client, _)
   if not utils.load_config().ui.lsp_semantic_tokens and client.supports_method "textDocument/semanticTokens" then
     client.server_capabilities.semanticTokensProvider = nil
   end
@@ -39,6 +41,7 @@ M.capabilities.textDocument.completion.completionItem = {
 }
 
 require("lspconfig").lua_ls.setup {
+  on_init = M.on_init,
   on_attach = M.on_attach,
   capabilities = M.capabilities,
 

--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -7,9 +7,6 @@ local utils = require "core.utils"
 -- export on_attach & capabilities for custom lspconfigs
 
 M.on_attach = function(client, bufnr)
-  client.server_capabilities.documentFormattingProvider = false
-  client.server_capabilities.documentRangeFormattingProvider = false
-
   utils.load_mappings("lspconfig", { buffer = bufnr })
 
   if client.server_capabilities.signatureHelpProvider then

--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -40,7 +40,7 @@ M.capabilities.textDocument.completion.completionItem = {
   },
 }
 
-require("lspconfig").lua_ls.setup {
+vim.lsp.config("lua_ls", {
   on_init = M.on_init,
   on_attach = M.on_attach,
   capabilities = M.capabilities,
@@ -62,6 +62,8 @@ require("lspconfig").lua_ls.setup {
       },
     },
   },
-}
+})
+
+vim.lsp.enable({ "lua_ls" })
 
 return M

--- a/lua/plugins/configs/telescope.lua
+++ b/lua/plugins/configs/telescope.lua
@@ -21,7 +21,6 @@ local options = {
       horizontal = {
         prompt_position = "top",
         preview_width = 0.55,
-        results_width = 0.8,
       },
       vertical = {
         mirror = false,

--- a/lua/plugins/configs/telescope.lua
+++ b/lua/plugins/configs/telescope.lua
@@ -49,7 +49,7 @@ local options = {
     },
   },
 
-  extensions_list = { "themes", "terms", "fzf" },
+  extensions_list = { "themes", "terms" },
   extensions = {
     fzf = {
       fuzzy = true,

--- a/lua/plugins/configs/telescope.lua
+++ b/lua/plugins/configs/telescope.lua
@@ -50,14 +50,6 @@ local options = {
   },
 
   extensions_list = { "themes", "terms" },
-  extensions = {
-    fzf = {
-      fuzzy = true,
-      override_generic_sorter = true,
-      override_file_sorter = true,
-      case_mode = "smart_case",
-    },
-  },
 }
 
 return options

--- a/lua/plugins/configs/treesitter.lua
+++ b/lua/plugins/configs/treesitter.lua
@@ -1,5 +1,5 @@
 local options = {
-  ensure_installed = { "lua" },
+  ensure_installed = { "lua", "vim", "vimdoc" },
 
   highlight = {
     enable = true,

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -31,9 +31,7 @@ local default_plugins = {
 
   {
     "NvChad/nvim-colorizer.lua",
-    init = function()
-      require("core.utils").lazy_load "nvim-colorizer.lua"
-    end,
+    event = "User FilePost",
     config = function(_, opts)
       require("colorizer").setup(opts)
 
@@ -58,9 +56,7 @@ local default_plugins = {
   {
     "lukas-reineke/indent-blankline.nvim",
     version = "2.20.7",
-    init = function()
-      require("core.utils").lazy_load "indent-blankline.nvim"
-    end,
+    event = "User FilePost",
     opts = function()
       return require("plugins.configs.others").blankline
     end,
@@ -73,10 +69,8 @@ local default_plugins = {
 
   {
     "nvim-treesitter/nvim-treesitter",
+    event = { "BufReadPost", "BufNewFile" },
     tag = "v0.9.2",
-    init = function()
-      require("core.utils").lazy_load "nvim-treesitter"
-    end,
     cmd = { "TSInstall", "TSBufEnable", "TSBufDisable", "TSModuleInfo" },
     build = ":TSUpdate",
     opts = function()
@@ -91,27 +85,7 @@ local default_plugins = {
   -- git stuff
   {
     "lewis6991/gitsigns.nvim",
-    ft = { "gitcommit", "diff" },
-    init = function()
-      -- load gitsigns only when a git file is opened
-      vim.api.nvim_create_autocmd({ "BufRead" }, {
-        group = vim.api.nvim_create_augroup("GitSignsLazyLoad", { clear = true }),
-        callback = function()
-          vim.fn.jobstart({"git", "-C", vim.loop.cwd(), "rev-parse"},
-            {
-              on_exit = function(_, return_code)
-                if return_code == 0 then
-                  vim.api.nvim_del_augroup_by_name "GitSignsLazyLoad"
-                  vim.schedule(function()
-                    require("lazy").load { plugins = { "gitsigns.nvim" } }
-                  end)
-                end
-              end
-            }
-          )
-        end,
-      })
-    end,
+    event = "User FilePost",
     opts = function()
       return require("plugins.configs.others").gitsigns
     end,
@@ -145,9 +119,7 @@ local default_plugins = {
 
   {
     "neovim/nvim-lspconfig",
-    init = function()
-      require("core.utils").lazy_load "nvim-lspconfig"
-    end,
+    event = "User FilePost",
     config = function()
       require "plugins.configs.lspconfig"
     end,

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -96,13 +96,18 @@ local default_plugins = {
       vim.api.nvim_create_autocmd({ "BufRead" }, {
         group = vim.api.nvim_create_augroup("GitSignsLazyLoad", { clear = true }),
         callback = function()
-          vim.fn.system("git -C " .. '"' .. vim.fn.expand "%:p:h" .. '"' .. " rev-parse")
-          if vim.v.shell_error == 0 then
-            vim.api.nvim_del_augroup_by_name "GitSignsLazyLoad"
-            vim.schedule(function()
-              require("lazy").load { plugins = { "gitsigns.nvim" } }
-            end)
-          end
+          vim.fn.jobstart({"git", "-C", vim.loop.cwd(), "rev-parse"},
+            {
+              on_exit = function(_, return_code)
+                if return_code == 0 then
+                  vim.api.nvim_del_augroup_by_name "GitSignsLazyLoad"
+                  vim.schedule(function()
+                    require("lazy").load { plugins = { "gitsigns.nvim" } }
+                  end)
+                end
+              end
+            }
+          )
         end,
       })
     end,

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -252,7 +252,7 @@ local default_plugins = {
   -- Only load whichkey after all the gui
   {
     "folke/which-key.nvim",
-    keys = { "<leader>", "<c-r>", '"', "'", "`", "c", "v", "g" },
+    keys = { "<leader>", "<c-r>", "<c-w>", '"', "'", "`", "c", "v", "g" },
     init = function()
       require("core.utils").load_mappings "whichkey"
     end,

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -19,7 +19,7 @@ local default_plugins = {
   },
 
   {
-    "NvChad/nvterm",
+    "zbirenbaum/nvterm",
     init = function()
       require("core.utils").load_mappings "nvterm"
     end,

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -73,6 +73,7 @@ local default_plugins = {
 
   {
     "nvim-treesitter/nvim-treesitter",
+    tag = "v0.9.2",
     init = function()
       require("core.utils").lazy_load "nvim-treesitter"
     end,

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -70,7 +70,6 @@ local default_plugins = {
   {
     "nvim-treesitter/nvim-treesitter",
     event = { "BufReadPost", "BufNewFile" },
-    tag = "v0.9.2",
     cmd = { "TSInstall", "TSBufEnable", "TSBufDisable", "TSModuleInfo" },
     build = ":TSUpdate",
     opts = function()

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -234,7 +234,7 @@ local default_plugins = {
 
   {
     "nvim-telescope/telescope.nvim",
-    dependencies = { "nvim-treesitter/nvim-treesitter", { "nvim-telescope/telescope-fzf-native.nvim", build = "make" } },
+    dependencies = { "nvim-treesitter/nvim-treesitter" },
     cmd = "Telescope",
     init = function()
       require("core.utils").load_mappings "telescope"

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -133,7 +133,9 @@ local default_plugins = {
 
       -- custom nvchad cmd to install all mason binaries listed
       vim.api.nvim_create_user_command("MasonInstallAll", function()
-        vim.cmd("MasonInstall " .. table.concat(opts.ensure_installed, " "))
+        if opts.ensure_installed and #opts.ensure_installed > 0 then
+          vim.cmd("MasonInstall " .. table.concat(opts.ensure_installed, " "))
+        end
       end, {})
 
       vim.g.mason_binaries_list = opts.ensure_installed


### PR DESCRIPTION

## Pull Request: Migrate `lua_ls` Configuration from Deprecated `lspconfig.setup` API

This PR addresses the deprecation warning issued by the `nvim-lspconfig` plugin and future-proofs our Language Server Protocol (LSP) configuration for Neovim v0.11+.

-----

## Bug/Issue Description 
The Neovim console displayed the following deprecation warning:

> The `require('lspconfig')` "framework" is deprecated, use `vim.lsp.config` (see `:help lspconfig-nvim-0.11`) instead. Feature will be removed in `nvim-lspconfig v3.0.0`

This warning is triggered by the Lua Language Server (`lua_ls`) configuration in `nvim/lua/plugins/configs/lspconfig.lua`, which uses the older, soon-to-be-removed `require("lspconfig").lua_ls.setup{}` API. While this currently functions, it relies on deprecated code that will break the configuration when `nvim-lspconfig` updates to version 3.0.0.

-----

## Technical Changes

This fix involves migrating the `lua_ls` configuration to the native Neovim LSP API, which is the recommended approach for modern Neovim configurations.

The legacy line:

```lua
require("lspconfig").lua_ls.setup { ... }
```

Has been replaced by two new functions:

1.  **`vim.lsp.config("lua_ls", { ... })`**: This function is used to statically define or customize the configuration options (like `on_init`, `on_attach`, `capabilities`, and `settings`) for the `lua_ls` server. All existing custom options have been preserved.
2.  **`vim.lsp.enable({ "lua_ls" })`**: This explicitly enables the defined configuration, ensuring the Language Server starts automatically for Lua files.

### Files Changed

  * `nvim/lua/plugins/configs/lspconfig.lua`

-----

## Verification and Testing

1.  Open Neovim. The deprecation warning **should no longer appear** upon startup.
2.  Open any Lua file (e.g., `init.lua`).
3.  Verify that Lua LSP features (e.g., autocompletion, diagnostics, go-to-definition for `vim.` functions) are working correctly, confirming that the new configuration was applied successfully.