### PR TITLE
Revert: fix: remove un-needed luasnip autocmd NvChad/ui#482

### DIFF
--- a/lua/nvchad/configs/luasnip.lua
+++ b/lua/nvchad/configs/luasnip.lua
@@ -9,3 +9,15 @@ require("luasnip.loaders.from_snipmate").lazy_load { paths = vim.g.snipmate_snip
 -- lua format
 require("luasnip.loaders.from_lua").load()
 require("luasnip.loaders.from_lua").lazy_load { paths = vim.g.lua_snippets_path or "" }
+
+-- fix luasnip #258
+vim.api.nvim_create_autocmd("InsertLeave", {
+  callback = function()
+    if
+      require("luasnip").session.current_nodes[vim.api.nvim_get_current_buf()]
+      and not require("luasnip").session.jump_active
+    then
+      require("luasnip").unlink_current()
+    end
+  end,
+})


### PR DESCRIPTION
This autocmd was added in a99a789f74479ec4a21984866c877aed2bff8af7 but removed in 478299d3455e22e375df468bba7cf9e2cadcc189

However, it is necessary to fix https://github.com/L3MON4D3/LuaSnip/issues/258 .

So I think it would be better to add it back.