### PR TITLE
fix(treesitter): nvim-treesitter crashes

### DIFF
--- a/lua/nvchad/autocmds.lua
+++ b/lua/nvchad/autocmds.lua
@@ -38,5 +38,8 @@ local create_cmd = vim.api.nvim_create_user_command
 create_cmd("TSInstallAll", function()
   local spec = require("lazy.core.config").plugins["nvim-treesitter"]
   local opts = type(spec.opts) == "table" and spec.opts or {}
-  require("nvim-treesitter").install(opts.ensure_installed)
-end, {})
+
+  if opts.ensure_installed then
+    require("nvim-treesitter").install(opts.ensure_installed, { summary = true })
+  end
+end, { desc = "Install all configured treesitter parsers" })

--- a/lua/nvchad/plugins/init.lua
+++ b/lua/nvchad/plugins/init.lua
@@ -156,11 +156,27 @@ return {
 
   {
     "nvim-treesitter/nvim-treesitter",
-    event = { "BufReadPost", "BufNewFile" },
-    cmd = { "TSInstall", "TSBufEnable", "TSBufDisable", "TSModuleInfo" },
-    build = ":TSUpdate | TSInstallAll",
+    lazy = false,
+    build = function()
+      local ts = require "nvim-treesitter"
+      local spec = require("lazy.core.config").plugins["nvim-treesitter"]
+      local opts = type(spec.opts) == "table" and spec.opts or {}
+
+      if opts.install_dir then
+        ts.setup { install_dir = opts.install_dir }
+      end
+
+      if opts.ensure_installed then
+        ts.install(opts.ensure_installed, { summary = true }):wait(300000)
+      end
+
+      ts.update(nil, { summary = true }):wait(300000)
+    end,
     opts = function()
       return require "nvchad.configs.treesitter"
+    end,
+    config = function(_, opts)
+      require("nvim-treesitter").setup { install_dir = opts.install_dir }
     end,
   },
 }


### PR DESCRIPTION
nvim-treesitter main is now an incompatible rewrite and explicitly does not support lazy-loading. NvChad already migrated partially, but the plugin spec still lazy-loads treesitter and still references removed legacy commands. 

also made treesitter loaded eagerly, which helps a lot in stability of the editor experience. 